### PR TITLE
Semantically correct the test data

### DIFF
--- a/netbox_dns/tests/test_api.py
+++ b/netbox_dns/tests/test_api.py
@@ -32,14 +32,14 @@ class ZoneAPITestCase(APITestCase):
         self.add_permissions("netbox_dns.add_zone")
         url = reverse("plugins-api:netbox_dns-api:zone-list")
         response = self.client.post(
-            f"{url}?format=json", {"name": "Name 1"}, **self.header
+            f"{url}?format=json", {"name": "zone7.example.com"}, **self.header
         )
         self.assertEqual(response.status_code, 201)
 
     def test_add_zone_without_permission(self):
         url = reverse("plugins-api:netbox_dns-api:zone-list")
         response = self.client.post(
-            f"{url}?format=json", {"name": "Name 1"}, **self.header
+            f"{url}?format=json", {"name": "zone8.example.com"}, **self.header
         )
         self.assertEqual(response.status_code, 403)
 
@@ -49,7 +49,7 @@ class ZoneAPITestCase(APITestCase):
 
         url = reverse("plugins-api:netbox_dns-api:zone-detail", kwargs={"pk": zone.id})
         response = self.client.delete(
-            f"{url}?format=json", {"name": "Name 1"}, **self.header
+            f"{url}?format=json", {"name": "zone7.example.com"}, **self.header
         )
         self.assertEqual(response.status_code, 204)
 
@@ -58,7 +58,7 @@ class ZoneAPITestCase(APITestCase):
 
         url = reverse("plugins-api:netbox_dns-api:zone-detail", kwargs={"pk": zone.id})
         response = self.client.delete(
-            f"{url}?format=json", {"name": "Name 1"}, **self.header
+            f"{url}?format=json", {"name": "zone7.example.com"}, **self.header
         )
         self.assertEqual(response.status_code, 403)
 
@@ -146,12 +146,12 @@ class RecordAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_view_record_detail_without_permission(self):
-        zone = Zone.objects.create(name="zone.com")
+        zone = Zone.objects.create(name="zone.example.com")
         record = Record.objects.create(
             zone=zone,
             type=Record.A,
-            name="Record 1",
-            value="Value 1",
+            name="name1",
+            value="192.168.1.1",
             ttl=100,
         )
 
@@ -164,12 +164,12 @@ class RecordAPITestCase(APITestCase):
     def test_view_record_detail_with_permission(self):
         self.add_permissions("netbox_dns.view_record")
 
-        zone = Zone.objects.create(name="zone.com")
+        zone = Zone.objects.create(name="zone.example.com")
         record = Record.objects.create(
             zone=zone,
             type=Record.A,
-            name="Record 1",
-            value="Value 1",
+            name="name1",
+            value="192.168.1.1",
             ttl=100,
         )
 

--- a/netbox_dns/tests/test_views.py
+++ b/netbox_dns/tests/test_views.py
@@ -23,24 +23,24 @@ class ZoneTestCase(
     def setUpTestData(cls):
         Zone.objects.bulk_create(
             [
-                Zone(name="Zone 1"),
-                Zone(name="Zone 2"),
-                Zone(name="Zone 3"),
+                Zone(name="zone1.example.com"),
+                Zone(name="zone2.example.com"),
+                Zone(name="zone3.example.com"),
             ]
         )
 
         tags = create_tags("Alpha", "Bravo", "Charlie")
 
         cls.form_data = {
-            "name": "Name1",
+            "name": "zone4.example.com",
             "tags": [t.pk for t in tags],
         }
 
         cls.csv_data = (
             "name,status",
-            "domain-4.com,active",
-            "domain-5.com,active",
-            "domain-6.com,active",
+            "zone5.example.com,active",
+            "zone6.example.com,active",
+            "zone7.example.com,active",
         )
 
         cls.bulk_edit_data = {
@@ -67,24 +67,24 @@ class NameServerTestCase(
     def setUpTestData(cls):
         NameServer.objects.bulk_create(
             [
-                NameServer(name="Name Server 1"),
-                NameServer(name="Name Server 2"),
-                NameServer(name="Name Server 3"),
+                NameServer(name="ns1.example.com"),
+                NameServer(name="ns2.example.com"),
+                NameServer(name="ns3.example.com"),
             ]
         )
 
         tags = create_tags("Alpha", "Bravo", "Charlie")
 
         cls.form_data = {
-            "name": "Name1",
+            "name": "ns4.example.com",
             "tags": [t.pk for t in tags],
         }
 
         cls.csv_data = (
             "name",
-            "name-server-4.com",
-            "name-server-5.com",
-            "name-server-6.com",
+            "ns5.example.com",
+            "ns6.example.com",
+            "ns7.example.com",
         )
 
     maxDiff = None
@@ -106,22 +106,22 @@ class RecordTestCase(
 
     @classmethod
     def setUpTestData(cls):
-        zone1 = Zone.objects.create(name="zone1.com")
-        zone2 = Zone.objects.create(name="zone2.com")
+        zone1 = Zone.objects.create(name="zone1.example.com")
+        zone2 = Zone.objects.create(name="zone2.example.com")
 
         records = [
             Record(
                 zone=zone1,
                 type=Record.CNAME,
-                name="name 1",
-                value="value 1",
+                name="name1",
+                value="test1.example.com",
                 ttl=100,
             ),
             Record(
                 zone=zone2,
                 type=Record.A,
-                name="name 2",
-                value="value 2",
+                name="name2",
+                value="192.168.1.1",
                 ttl=200,
             ),
         ]
@@ -133,18 +133,18 @@ class RecordTestCase(
         cls.form_data = {
             "zone": zone1.id,
             "type": Record.AAAA,
-            "name": "name 3",
-            "value": "value 300",
+            "name": "name3",
+            "value": "fe80::dead:beef",
             "ttl": 300,
             "tags": [t.pk for t in tags],
         }
 
         cls.csv_data = (
             "zone,type,name,value,ttl",
-            "zone1.com,A,@,10.10.10.10,3600",
-            "zone2.com,AAAA,ipv6sub,[00:00],7200",
-            "zone1.com,CNAME,dns,100.100.100.100,100",
-            "zone2.com,TXT,textname,textvalue,1000",
+            "zone1.example.com,A,@,10.10.10.10,3600",
+            "zone2.example.com,AAAA,name4,[fe80::dead:beef],7200",
+            "zone1.example.com,CNAME,dns,name1.zone2.example.com,100",
+            "zone2.example.com,TXT,textname,textvalue,1000",
         )
 
         cls.bulk_edit_data = {


### PR DESCRIPTION
This patch mainly targets the values for A and AAAA records, but some other
names, i.e. for name servers and zones, are now legal values as well. This
should be useful when more tests and more validation will be implemented.

Fixes #37