### PR TITLE
fix workflow until #89 fix.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: "netbox-community/netbox"
+          ref: 'v3.0.12'
           path: netbox
 
       - name: install netbox_dns


### PR DESCRIPTION
Netbox 3.1 has breaking changes. For now run tests with v3.0.12.

Please see: #89