### PR TITLE
Netbox 3.1 compatibility fixes

### DIFF
--- a/netbox_dns/api/serializers.py
+++ b/netbox_dns/api/serializers.py
@@ -21,7 +21,6 @@ class NameServerSerializer(PrimaryModelSerializer):
             "display",
             "name",
             "tags",
-            "custom_field_data",
             "created",
             "last_updated",
         )
@@ -56,7 +55,6 @@ class RecordSerializer(PrimaryModelSerializer):
             "value",
             "ttl",
             "tags",
-            "custom_field_data",
             "created",
             "last_updated",
             "managed",
@@ -91,7 +89,6 @@ class ZoneSerializer(PrimaryModelSerializer):
             "status",
             "nameservers",
             "tags",
-            "custom_field_data",
             "created",
             "last_updated",
             "default_ttl",

--- a/netbox_dns/api/views.py
+++ b/netbox_dns/api/views.py
@@ -3,7 +3,8 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.routers import APIRootView
 
-from extras.api.views import CustomFieldModelViewSet
+from netbox.api.views import ModelViewSet
+
 from netbox_dns.api.serializers import (
     ZoneSerializer,
     NameServerSerializer,
@@ -22,7 +23,7 @@ class NetboxDNSRootView(APIRootView):
         return "NetboxDNS"
 
 
-class ZoneViewSet(CustomFieldModelViewSet):
+class ZoneViewSet(ModelViewSet):
     queryset = Zone.objects.all()
     serializer_class = ZoneSerializer
     filterset_class = ZoneFilter
@@ -42,7 +43,7 @@ class ZoneViewSet(CustomFieldModelViewSet):
         return Response(serializer.data)
 
 
-class NameServerViewSet(CustomFieldModelViewSet):
+class NameServerViewSet(ModelViewSet):
     queryset = NameServer.objects.all()
     serializer_class = NameServerSerializer
     filterset_class = NameServerFilter
@@ -54,7 +55,7 @@ class NameServerViewSet(CustomFieldModelViewSet):
         return Response(serializer.data)
 
 
-class RecordViewSet(CustomFieldModelViewSet):
+class RecordViewSet(ModelViewSet):
     queryset = Record.objects.all()
     serializer_class = RecordSerializer
     filterset_class = RecordFilter

--- a/netbox_dns/forms.py
+++ b/netbox_dns/forms.py
@@ -14,7 +14,6 @@ from extras.models.tags import Tag
 
 from utilities.forms import (
     CSVModelForm,
-    BulkEditForm,
     BootstrapMixin,
     BulkEditNullBooleanSelect,
     DynamicModelMultipleChoiceField,
@@ -29,6 +28,18 @@ from utilities.forms import (
 )
 from .fields import CustomDynamicModelMultipleChoiceField
 from .models import NameServer, Record, Zone
+
+
+class BulkEditForm(forms.Form):
+    """Base form for editing multiple objects in bulk"""
+
+    def __init__(self, model, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.model = model
+        self.nullable_fields = []
+
+        if hasattr(self.Meta, "nullable_fields"):
+            self.nullable_fields = self.Meta.nullable_fields
 
 
 class ZoneForm(BootstrapMixin, forms.ModelForm):
@@ -347,7 +358,6 @@ class ZoneBulkEditForm(BootstrapMixin, AddRemoveTagsForm, BulkEditForm):
 
     class Meta:
         nullable_fields = []
-
         model = Zone
         fields = (
             "name",

--- a/netbox_dns/forms.py
+++ b/netbox_dns/forms.py
@@ -9,15 +9,12 @@ from django.core.validators import (
 from django.forms import CharField, IntegerField
 from django.urls import reverse_lazy
 
-from extras.forms import (
-    CustomFieldModelForm,
-    CustomFieldModelCSVForm,
-    AddRemoveTagsForm,
-    CustomFieldModelBulkEditForm,
-    CustomFieldModelFilterForm,
-)
+from extras.forms import AddRemoveTagsForm
 from extras.models.tags import Tag
+
 from utilities.forms import (
+    CSVModelForm,
+    BulkEditForm,
     BootstrapMixin,
     BulkEditNullBooleanSelect,
     DynamicModelMultipleChoiceField,
@@ -34,7 +31,7 @@ from .fields import CustomDynamicModelMultipleChoiceField
 from .models import NameServer, Record, Zone
 
 
-class ZoneForm(BootstrapMixin, CustomFieldModelForm):
+class ZoneForm(BootstrapMixin, forms.ModelForm):
     """Form for creating a new Zone object."""
 
     def __init__(self, *args, **kwargs):
@@ -150,7 +147,7 @@ class ZoneForm(BootstrapMixin, CustomFieldModelForm):
         }
 
 
-class ZoneFilterForm(BootstrapMixin, CustomFieldModelFilterForm):
+class ZoneFilterForm(BootstrapMixin, forms.Form):
     """Form for filtering Zone instances."""
 
     model = Zone
@@ -172,7 +169,7 @@ class ZoneFilterForm(BootstrapMixin, CustomFieldModelFilterForm):
     tag = TagFilterField(Zone)
 
 
-class ZoneCSVForm(CustomFieldModelCSVForm):
+class ZoneCSVForm(CSVModelForm, BootstrapMixin, forms.ModelForm):
     status = CSVChoiceField(
         choices=Zone.CHOICES,
         help_text="Zone status",
@@ -284,7 +281,7 @@ class ZoneCSVForm(CustomFieldModelCSVForm):
         )
 
 
-class ZoneBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldModelBulkEditForm):
+class ZoneBulkEditForm(BootstrapMixin, AddRemoveTagsForm, BulkEditForm):
     pk = forms.ModelMultipleChoiceField(
         queryset=Zone.objects.all(),
         widget=forms.MultipleHiddenInput(),
@@ -384,7 +381,7 @@ class NameServerForm(BootstrapMixin, forms.ModelForm):
         fields = ("name", "tags")
 
 
-class NameServerFilterForm(BootstrapMixin, CustomFieldModelFilterForm):
+class NameServerFilterForm(BootstrapMixin, forms.Form):
     """Form for filtering NameServer instances."""
 
     model = NameServer
@@ -400,7 +397,7 @@ class NameServerFilterForm(BootstrapMixin, CustomFieldModelFilterForm):
     tag = TagFilterField(NameServer)
 
 
-class NameServerCSVForm(CustomFieldModelCSVForm):
+class NameServerCSVForm(CSVModelForm, BootstrapMixin, forms.ModelForm):
     class Meta:
         model = NameServer
         fields = ("name",)
@@ -482,7 +479,7 @@ class RecordForm(BootstrapMixin, forms.ModelForm):
         }
 
 
-class RecordFilterForm(BootstrapMixin, CustomFieldModelFilterForm):
+class RecordFilterForm(BootstrapMixin, forms.Form):
     """Form for filtering Record instances."""
 
     model = Record
@@ -512,7 +509,7 @@ class RecordFilterForm(BootstrapMixin, CustomFieldModelFilterForm):
     tag = TagFilterField(Record)
 
 
-class RecordCSVForm(CustomFieldModelCSVForm):
+class RecordCSVForm(CSVModelForm, BootstrapMixin, forms.ModelForm):
     zone = CSVModelChoiceField(
         queryset=Zone.objects.all(),
         to_field_name="name",
@@ -585,9 +582,7 @@ class RecordCSVForm(CustomFieldModelCSVForm):
         fields = ("zone", "type", "name", "value", "ttl", "disable_ptr")
 
 
-class RecordBulkEditForm(
-    BootstrapMixin, AddRemoveTagsForm, CustomFieldModelBulkEditForm
-):
+class RecordBulkEditForm(BootstrapMixin, AddRemoveTagsForm, BulkEditForm):
     pk = forms.ModelMultipleChoiceField(
         queryset=Record.objects.all(), widget=forms.MultipleHiddenInput()
     )

--- a/netbox_dns/models.py
+++ b/netbox_dns/models.py
@@ -15,7 +15,7 @@ from netbox.models import PrimaryModel, TaggableManager
 from utilities.querysets import RestrictedQuerySet
 
 
-@extras_features("custom_fields", "custom_links", "export_templates", "webhooks")
+@extras_features("custom_links", "export_templates", "webhooks")
 class NameServer(PrimaryModel):
     name = models.CharField(
         unique=True,
@@ -40,7 +40,7 @@ class NameServer(PrimaryModel):
         return reverse("plugins:netbox_dns:nameserver", kwargs={"pk": self.pk})
 
 
-@extras_features("custom_fields", "custom_links", "export_templates", "webhooks")
+@extras_features("custom_links", "export_templates", "webhooks")
 class Zone(PrimaryModel):
     STATUS_ACTIVE = "active"
     STATUS_PASSIVE = "passive"
@@ -296,7 +296,7 @@ def update_ns_records(**kwargs):
     zone.update_ns_records(new_nameservers)
 
 
-@extras_features("custom_fields", "custom_links", "export_templates", "webhooks")
+@extras_features("custom_links", "export_templates", "webhooks")
 class Record(PrimaryModel):
     A = "A"
     AAAA = "AAAA"

--- a/netbox_dns/templates/netbox_dns/nameserver.html
+++ b/netbox_dns/templates/netbox_dns/nameserver.html
@@ -19,7 +19,6 @@
                     </table>
                 </div>
             </div>
-            {% include 'inc/custom_fields_panel.html' %}
         </div>
         <div class="col col-md-6">
             {% include 'extras/inc/tags_panel.html' with tags=object.tags.all url='plugins:netbox_dns:nameserver_list' %}

--- a/netbox_dns/templates/netbox_dns/nameserver.html
+++ b/netbox_dns/templates/netbox_dns/nameserver.html
@@ -21,7 +21,11 @@
             </div>
         </div>
         <div class="col col-md-6">
-            {% include 'extras/inc/tags_panel.html' with tags=object.tags.all url='plugins:netbox_dns:nameserver_list' %}
+            {% if netbox_version < '3.1.0' %}
+                {% include 'extras/inc/tags_panel.html' with tags=object.tags.all url='plugins:netbox_dns:nameserver_list' %}
+            {% else %}
+                {% include 'inc/panels/tags.html' with tags=object.tags.all url='plugins:netbox_dns:nameserver_list' %}
+            {% endif %}
         </div>
     </div>
 

--- a/netbox_dns/templates/netbox_dns/record.html
+++ b/netbox_dns/templates/netbox_dns/record.html
@@ -80,7 +80,6 @@
                     {% endif %}
                 </table>
             </div>
-            {% include 'inc/custom_fields_panel.html' %}
         </div>
     </div>
     {% if not object.managed %}

--- a/netbox_dns/templates/netbox_dns/record.html
+++ b/netbox_dns/templates/netbox_dns/record.html
@@ -84,7 +84,11 @@
     </div>
     {% if not object.managed %}
     <div class="col col-md-4">
-        {% include 'extras/inc/tags_panel.html' with tags=object.tags.all url='plugins:netbox_dns:zone_list' %}
+        {% if netbox_version < '3.1.0' %}
+            {% include 'extras/inc/tags_panel.html' with tags=object.tags.all url='plugins:netbox_dns:record_list' %}
+        {% else %}
+            {% include 'inc/panels/tags.html' with tags=object.tags.all url='plugins:netbox_dns:record_list' %}
+        {% endif %}
     </div>
     {% endif %}
 </div>

--- a/netbox_dns/templates/netbox_dns/zone.html
+++ b/netbox_dns/templates/netbox_dns/zone.html
@@ -71,7 +71,6 @@
             </div>
         </div>
         {% include 'extras/inc/tags_panel.html' with tags=object.tags.all url='plugins:netbox_dns:zone_list' %}
-        {% include 'inc/custom_fields_panel.html' %}
     </div>
     <div class="col col-md-6">
         <div class="card">

--- a/netbox_dns/templates/netbox_dns/zone.html
+++ b/netbox_dns/templates/netbox_dns/zone.html
@@ -70,7 +70,11 @@
                 </table>
             </div>
         </div>
-        {% include 'extras/inc/tags_panel.html' with tags=object.tags.all url='plugins:netbox_dns:zone_list' %}
+        {% if netbox_version < '3.1.0' %}
+            {% include 'extras/inc/tags_panel.html' with tags=object.tags.all url='plugins:netbox_dns:zone_list' %}
+        {% else %}
+            {% include 'inc/panels/tags.html' with tags=object.tags.all url='plugins:netbox_dns:zone_list' %}
+        {% endif %}
     </div>
     <div class="col col-md-6">
         <div class="card">

--- a/netbox_dns/tests/test_api.py
+++ b/netbox_dns/tests/test_api.py
@@ -24,7 +24,6 @@ class ZoneTest(
     model = Zone
     brief_fields = [
         "created",
-        "custom_field_data",
         "default_ttl",
         "display",
         "id",

--- a/netbox_dns/views.py
+++ b/netbox_dns/views.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+
 from netbox.views import generic
 from netbox_dns.filters import NameServerFilter, RecordFilter, ZoneFilter
 from netbox_dns.forms import (
@@ -51,6 +53,7 @@ class ZoneView(generic.ObjectView):
         return {
             "nameserver_warnings": ns_warnings,
             "nameserver_errors": ns_errors,
+            "netbox_version": settings.VERSION,
         }
 
 
@@ -169,6 +172,7 @@ class NameServerView(generic.ObjectView):
                 "delete": delete_zone,
             },
             "model": Zone,
+            "netbox_version": settings.VERSION,
         }
 
 
@@ -219,6 +223,11 @@ class RecordView(generic.ObjectView):
     """Display Zone details"""
 
     queryset = Record.objects.all()
+
+    def get_extra_context(self, request, instance):
+        return {
+            "netbox_version": settings.VERSION,
+        }
 
 
 class RecordEditView(generic.ObjectEditView):


### PR DESCRIPTION
fixes #89 (kind of)

Turns out there are a few more incompatible changes in 3.1.

The CustomField* classes are relatively uncritical as we actually don't use the functionality added by them, so I just replaced them with the corresponding non-CustomField methods. I'm not really sure that will put us on the safe side in the long run, but with 3.1 it is doing the trick. 

Class BulkEditForm also implicitly inherits from BootstrapMixin implicitly, so we have the same issue here. Since we actually need its functionality (and it it pretty simple and short) I saw no better way in dealing with this than to copy it and include it in the forms.py module.

A different issue is, however, that the template `tags_panel.html` was renamed to `tags.html' in 3.1., breaking three of our templates, and we **do** support tags. The solution I implemented is not really elegant, but it works for the time being: I pass the Netbox version string to the templates in question, and include the panel template conditionally on whether Netbox 3.1 or an older version was detected.

I've tested this with Netbox 3.1 and 3.0.12, and both tests ran successfully.