### PR TITLE
Fixed validated viewnames in templates

### DIFF
--- a/netbox_dns/templates/netbox_dns/object_list.html
+++ b/netbox_dns/templates/netbox_dns/object_list.html
@@ -56,7 +56,7 @@
 
       {# "Select all" form #}
       {% if table.paginator.num_pages > 1 %}
-        {% with bulk_edit_url=content_type.model_class|validated_viewname:"bulk_edit" bulk_delete_url=content_type.model_class|validated_viewname:"bulk_delete" %}
+        {% with bulk_edit_url=content_type.model_class|plugin_validated_viewname:"bulk_edit" bulk_delete_url=content_type.model_class|plugin_validated_viewname:"bulk_delete" %}
           <div id="select-all-box" class="d-none card noprint">
             <form method="post" class="form col-md-12">
               {% csrf_token %}

--- a/netbox_dns/templates/netbox_dns/record_list.html
+++ b/netbox_dns/templates/netbox_dns/record_list.html
@@ -56,7 +56,7 @@
 
       {# "Select all" form #}
       {% if table.paginator.num_pages > 1 %}
-        {% with bulk_edit_url=content_type.model_class|validated_viewname:"bulk_edit" bulk_delete_url=content_type.model_class|validated_viewname:"bulk_delete" %}
+          {% with bulk_edit_url=content_type.model_class|plugin_validated_viewname:"bulk_edit" bulk_delete_url=content_type.model_class|plugin_validated_viewname:"bulk_delete" %}
           <div id="select-all-box" class="d-none card noprint">
             <form method="post" class="form col-md-12">
               {% csrf_token %}


### PR DESCRIPTION
Replace `validated_viewname` by `plugin_validated_viewname` in object list-like templates.

fixes #93