### PR TITLE
Implemented Netbox 3.1 compatibility fixes

### DIFF
--- a/netbox_dns/api/serializers.py
+++ b/netbox_dns/api/serializers.py
@@ -21,7 +21,6 @@ class NameServerSerializer(PrimaryModelSerializer):
             "display",
             "name",
             "tags",
-            "custom_field_data",
             "created",
             "last_updated",
         )
@@ -56,7 +55,6 @@ class RecordSerializer(PrimaryModelSerializer):
             "value",
             "ttl",
             "tags",
-            "custom_field_data",
             "created",
             "last_updated",
             "managed",
@@ -91,7 +89,6 @@ class ZoneSerializer(PrimaryModelSerializer):
             "status",
             "nameservers",
             "tags",
-            "custom_field_data",
             "created",
             "last_updated",
             "default_ttl",

--- a/netbox_dns/api/views.py
+++ b/netbox_dns/api/views.py
@@ -3,7 +3,8 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.routers import APIRootView
 
-from extras.api.views import CustomFieldModelViewSet
+from netbox.api.views import ModelViewSet
+
 from netbox_dns.api.serializers import (
     ZoneSerializer,
     NameServerSerializer,
@@ -22,7 +23,7 @@ class NetboxDNSRootView(APIRootView):
         return "NetboxDNS"
 
 
-class ZoneViewSet(CustomFieldModelViewSet):
+class ZoneViewSet(ModelViewSet):
     queryset = Zone.objects.all()
     serializer_class = ZoneSerializer
     filterset_class = ZoneFilter
@@ -42,7 +43,7 @@ class ZoneViewSet(CustomFieldModelViewSet):
         return Response(serializer.data)
 
 
-class NameServerViewSet(CustomFieldModelViewSet):
+class NameServerViewSet(ModelViewSet):
     queryset = NameServer.objects.all()
     serializer_class = NameServerSerializer
     filterset_class = NameServerFilter
@@ -54,7 +55,7 @@ class NameServerViewSet(CustomFieldModelViewSet):
         return Response(serializer.data)
 
 
-class RecordViewSet(CustomFieldModelViewSet):
+class RecordViewSet(ModelViewSet):
     queryset = Record.objects.all()
     serializer_class = RecordSerializer
     filterset_class = RecordFilter

--- a/netbox_dns/forms.py
+++ b/netbox_dns/forms.py
@@ -466,9 +466,7 @@ class NameServerCSVForm(CSVModelForm, BootstrapMixin, forms.ModelForm):
         fields = ("name",)
 
 
-class NameServerBulkEditForm(
-    BootstrapMixin, AddRemoveTagsForm, CustomFieldModelBulkEditForm
-):
+class NameServerBulkEditForm(BootstrapMixin, AddRemoveTagsForm, BulkEditForm):
     pk = forms.ModelMultipleChoiceField(
         queryset=NameServer.objects.all(),
         widget=forms.MultipleHiddenInput(),

--- a/netbox_dns/models.py
+++ b/netbox_dns/models.py
@@ -18,7 +18,7 @@ from netbox.models import PrimaryModel, TaggableManager
 from utilities.querysets import RestrictedQuerySet
 
 
-@extras_features("custom_fields", "custom_links", "export_templates", "webhooks")
+@extras_features("custom_links", "export_templates", "webhooks")
 class NameServer(PrimaryModel):
     name = models.CharField(
         unique=True,
@@ -43,7 +43,7 @@ class NameServer(PrimaryModel):
         return reverse("plugins:netbox_dns:nameserver", kwargs={"pk": self.pk})
 
 
-@extras_features("custom_fields", "custom_links", "export_templates", "webhooks")
+@extras_features("custom_links", "export_templates", "webhooks")
 class Zone(PrimaryModel):
     STATUS_ACTIVE = "active"
     STATUS_PASSIVE = "passive"
@@ -327,7 +327,7 @@ def update_ns_records(**kwargs):
     zone.update_ns_records(new_nameservers)
 
 
-@extras_features("custom_fields", "custom_links", "export_templates", "webhooks")
+@extras_features("custom_links", "export_templates", "webhooks")
 class Record(PrimaryModel):
     A = "A"
     AAAA = "AAAA"

--- a/netbox_dns/templates/netbox_dns/nameserver.html
+++ b/netbox_dns/templates/netbox_dns/nameserver.html
@@ -19,10 +19,13 @@
                     </table>
                 </div>
             </div>
-            {% include 'inc/custom_fields_panel.html' %}
         </div>
         <div class="col col-md-6">
-            {% include 'extras/inc/tags_panel.html' with tags=object.tags.all url='plugins:netbox_dns:nameserver_list' %}
+            {% if netbox_version < '3.1.0' %}
+                {% include 'extras/inc/tags_panel.html' with tags=object.tags.all url='plugins:netbox_dns:nameserver_list' %}
+            {% else %}
+                {% include 'inc/panels/tags.html' with tags=object.tags.all url='plugins:netbox_dns:nameserver_list' %}
+            {% endif %}
         </div>
     </div>
 

--- a/netbox_dns/templates/netbox_dns/record.html
+++ b/netbox_dns/templates/netbox_dns/record.html
@@ -80,12 +80,15 @@
                     {% endif %}
                 </table>
             </div>
-            {% include 'inc/custom_fields_panel.html' %}
         </div>
     </div>
     {% if not object.managed %}
     <div class="col col-md-4">
-        {% include 'extras/inc/tags_panel.html' with tags=object.tags.all url='plugins:netbox_dns:zone_list' %}
+        {% if netbox_version < '3.1.0' %}
+            {% include 'extras/inc/tags_panel.html' with tags=object.tags.all url='plugins:netbox_dns:record_list' %}
+        {% else %}
+            {% include 'inc/panels/tags.html' with tags=object.tags.all url='plugins:netbox_dns:record_list' %}
+        {% endif %}
     </div>
     {% endif %}
 </div>

--- a/netbox_dns/templates/netbox_dns/zone.html
+++ b/netbox_dns/templates/netbox_dns/zone.html
@@ -70,8 +70,11 @@
                 </table>
             </div>
         </div>
-        {% include 'extras/inc/tags_panel.html' with tags=object.tags.all url='plugins:netbox_dns:zone_list' %}
-        {% include 'inc/custom_fields_panel.html' %}
+        {% if netbox_version < '3.1.0' %}
+            {% include 'extras/inc/tags_panel.html' with tags=object.tags.all url='plugins:netbox_dns:zone_list' %}
+        {% else %}
+            {% include 'inc/panels/tags.html' with tags=object.tags.all url='plugins:netbox_dns:zone_list' %}
+        {% endif %}
     </div>
     <div class="col col-md-6">
         <div class="card">

--- a/netbox_dns/tests/test_api.py
+++ b/netbox_dns/tests/test_api.py
@@ -24,7 +24,6 @@ class ZoneTest(
     model = Zone
     brief_fields = [
         "created",
-        "custom_field_data",
         "default_ttl",
         "display",
         "id",

--- a/netbox_dns/views.py
+++ b/netbox_dns/views.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+
 from netbox.views import generic
 from netbox_dns.filters import NameServerFilter, RecordFilter, ZoneFilter
 from netbox_dns.forms import (
@@ -52,6 +54,7 @@ class ZoneView(generic.ObjectView):
         return {
             "nameserver_warnings": ns_warnings,
             "nameserver_errors": ns_errors,
+            "netbox_version": settings.VERSION,
         }
 
 
@@ -171,6 +174,7 @@ class NameServerView(generic.ObjectView):
                 "delete": delete_zone,
             },
             "model": Zone,
+            "netbox_version": settings.VERSION,
         }
 
 
@@ -228,6 +232,11 @@ class RecordView(generic.ObjectView):
     """Display Zone details"""
 
     queryset = Record.objects.all()
+
+    def get_extra_context(self, request, instance):
+        return {
+            "netbox_version": settings.VERSION,
+        }
 
 
 class RecordEditView(generic.ObjectEditView):


### PR DESCRIPTION
fixes #89 (kind of)

Turns out there are a few more incompatible changes in 3.1.

The CustomField* classes are relatively uncritical as we actually don't use the functionality added by them, so I just replaced them with the corresponding non-CustomField methods. I'm not really sure that will put us on the safe side in the long run, but with 3.1 it is doing the trick.

Class BulkEditForm also implicitly inherits from BootstrapMixin implicitly, so we have the same issue here. Since we actually need its functionality (and it it pretty simple and short) I saw no better way in dealing with this than to copy it and include it in the forms.py module.

A different issue is, however, that the template tags_panel.html was renamed to `tags.html' in 3.1., breaking three of our templates, and we do support tags. The solution I implemented is not really elegant, but it works for the time being: I pass the Netbox version string to the templates in question, and include the panel template conditionally on whether Netbox 3.1 or an older version was detected.

I've tested this with Netbox 3.1 and 3.0.12, and both tests ran successfully.