### PR TITLE
fix NetBox 3.1.2 release breaking changes

### DIFF
--- a/.github/workflows/test-nb-3.0.x.yml
+++ b/.github/workflows/test-nb-3.0.x.yml
@@ -1,7 +1,7 @@
-name: Test NetBox Latest
+name: Test NetBox 3.0.X Versions
 on: [push, pull_request]
 jobs:
-  test-netbox-latest:
+  test-netbox-3.0.X:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: "netbox-community/netbox"
+          ref: 'v3.0.12'
           path: netbox
 
       - name: install netbox_dns

--- a/.github/workflows/test-nb-3.0.x.yml
+++ b/.github/workflows/test-nb-3.0.x.yml
@@ -1,7 +1,7 @@
 name: Test NetBox 3.0.X Versions
 on: [push, pull_request]
 jobs:
-  test-netbox-3.0.X:
+  test-netbox-3_0_X:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/netbox_dns/templates/netbox_dns/managed_record_list.html
+++ b/netbox_dns/templates/netbox_dns/managed_record_list.html
@@ -48,7 +48,7 @@
       {% endif %}
 
       {# Object table controls #}
-      {% if netbox_version < '3.1.2' %}
+      {% if settings.VERSION < '3.1.2' %}
         {% include 'inc/table_controls.html' with table_modal="ManagedRecordTable_config" %}
       {% else %}
         {% include 'inc/table_controls_htmx.html' with table_modal="ManagedRecordTable_config" %}

--- a/netbox_dns/templates/netbox_dns/managed_record_list.html
+++ b/netbox_dns/templates/netbox_dns/managed_record_list.html
@@ -48,7 +48,11 @@
       {% endif %}
 
       {# Object table controls #}
-      {% include 'inc/table_controls.html' with table_modal="ManagedRecordTable_config" %}
+      {% if netbox_version < '3.1.2' %}
+        {% include 'inc/table_controls.html' with table_modal="ManagedRecordTable_config" %}
+      {% else %}
+        {% include 'inc/table_controls_htmx.html' with table_modal="ManagedRecordTable_config" %}
+      {% endif %}
 
       {# Object table #}
       <div class="card">

--- a/netbox_dns/templates/netbox_dns/nameserver.html
+++ b/netbox_dns/templates/netbox_dns/nameserver.html
@@ -21,7 +21,7 @@
             </div>
         </div>
         <div class="col col-md-6">
-            {% if netbox_version < '3.1.0' %}
+            {% if settings.VERSION < '3.1.0' %}
                 {% include 'extras/inc/tags_panel.html' with tags=object.tags.all url='plugins:netbox_dns:nameserver_list' %}
             {% else %}
                 {% include 'inc/panels/tags.html' with tags=object.tags.all url='plugins:netbox_dns:nameserver_list' %}
@@ -68,7 +68,7 @@
                     {% endif %}
 
                     {# Object table controls #}
-                    {% if netbox_version < '3.1.2' %}
+                    {% if settings.VERSION < '3.1.2' %}
                         {% include 'inc/table_controls.html' with table_modal="ZoneTable_config" %}
                     {% else %}
                         {% include 'inc/table_controls_htmx.html' with table_modal="ZoneTable_config" %}

--- a/netbox_dns/templates/netbox_dns/nameserver.html
+++ b/netbox_dns/templates/netbox_dns/nameserver.html
@@ -68,7 +68,11 @@
                     {% endif %}
 
                     {# Object table controls #}
-                    {% include 'inc/table_controls.html' with table_modal="ZoneTable_config" %}
+                    {% if netbox_version < '3.1.2' %}
+                        {% include 'inc/table_controls.html' with table_modal="ZoneTable_config" %}
+                    {% else %}
+                        {% include 'inc/table_controls_htmx.html' with table_modal="ZoneTable_config" %}
+                    {% endif %}
 
                     <form method="post" class="form form-horizontal">
                         {% csrf_token %}

--- a/netbox_dns/templates/netbox_dns/object_list.html
+++ b/netbox_dns/templates/netbox_dns/object_list.html
@@ -86,7 +86,11 @@
       {% endif %}
 
       {# Object table controls #}
-      {% include 'inc/table_controls.html' with table_modal="ObjectTable_config" %}
+      {% if netbox_version < '3.1.2' %}
+        {% include 'inc/table_controls.html' with table_modal="ObjectTable_config" %}
+      {% else %}
+        {% include 'inc/table_controls_htmx.html' with table_modal="ObjectTable_config" %}
+      {% endif %}
 
       <form method="post" class="form form-horizontal">
         {% csrf_token %}

--- a/netbox_dns/templates/netbox_dns/object_list.html
+++ b/netbox_dns/templates/netbox_dns/object_list.html
@@ -86,7 +86,7 @@
       {% endif %}
 
       {# Object table controls #}
-      {% if netbox_version < '3.1.2' %}
+      {% if settings.VERSION < '3.1.2' %}
         {% include 'inc/table_controls.html' with table_modal="ObjectTable_config" %}
       {% else %}
         {% include 'inc/table_controls_htmx.html' with table_modal="ObjectTable_config" %}

--- a/netbox_dns/templates/netbox_dns/record.html
+++ b/netbox_dns/templates/netbox_dns/record.html
@@ -84,7 +84,7 @@
     </div>
     {% if not object.managed %}
     <div class="col col-md-4">
-        {% if netbox_version < '3.1.0' %}
+        {% if settings.VERSION < '3.1.0' %}
             {% include 'extras/inc/tags_panel.html' with tags=object.tags.all url='plugins:netbox_dns:record_list' %}
         {% else %}
             {% include 'inc/panels/tags.html' with tags=object.tags.all url='plugins:netbox_dns:record_list' %}

--- a/netbox_dns/templates/netbox_dns/record_list.html
+++ b/netbox_dns/templates/netbox_dns/record_list.html
@@ -86,7 +86,11 @@
       {% endif %}
 
       {# Object table controls #}
-      {% include 'inc/table_controls.html' with table_modal="RecordTable_config" %}
+      {% if netbox_version < '3.1.2' %}
+        {% include 'inc/table_controls.html' with table_modal="RecordTable_config" %}
+      {% else %}
+        {% include 'inc/table_controls_htmx.html' with table_modal="RecordTable_config" %}
+      {% endif %}
 
       <form method="post" class="form form-horizontal">
         {% csrf_token %}

--- a/netbox_dns/templates/netbox_dns/record_list.html
+++ b/netbox_dns/templates/netbox_dns/record_list.html
@@ -86,7 +86,7 @@
       {% endif %}
 
       {# Object table controls #}
-      {% if netbox_version < '3.1.2' %}
+      {% if settings.VERSION < '3.1.2' %}
         {% include 'inc/table_controls.html' with table_modal="RecordTable_config" %}
       {% else %}
         {% include 'inc/table_controls_htmx.html' with table_modal="RecordTable_config" %}

--- a/netbox_dns/templates/netbox_dns/zone.html
+++ b/netbox_dns/templates/netbox_dns/zone.html
@@ -70,7 +70,7 @@
                 </table>
             </div>
         </div>
-        {% if netbox_version < '3.1.0' %}
+        {% if settings.VERSION < '3.1.0' %}
             {% include 'extras/inc/tags_panel.html' with tags=object.tags.all url='plugins:netbox_dns:zone_list' %}
         {% else %}
             {% include 'inc/panels/tags.html' with tags=object.tags.all url='plugins:netbox_dns:zone_list' %}

--- a/netbox_dns/templates/netbox_dns/zone_managed_record.html
+++ b/netbox_dns/templates/netbox_dns/zone_managed_record.html
@@ -18,7 +18,7 @@
       {% endif %}
 
       {# Object table controls #}
-      {% if netbox_version < '3.1.2' %}
+      {% if settings.VERSION < '3.1.2' %}
         {% include 'inc/table_controls.html' with table_modal="ZoneManagedRecordTable_config" %}
       {% else %}
         {% include 'inc/table_controls_htmx.html' with table_modal="ZoneManagedRecordTable_config" %}

--- a/netbox_dns/templates/netbox_dns/zone_managed_record.html
+++ b/netbox_dns/templates/netbox_dns/zone_managed_record.html
@@ -18,7 +18,11 @@
       {% endif %}
 
       {# Object table controls #}
-      {% include 'inc/table_controls.html' with table_modal="ZoneManagedRecordTable_config" %}
+      {% if netbox_version < '3.1.2' %}
+        {% include 'inc/table_controls.html' with table_modal="ZoneManagedRecordTable_config" %}
+      {% else %}
+        {% include 'inc/table_controls_htmx.html' with table_modal="ZoneManagedRecordTable_config" %}
+      {% endif %}
 
       <form method="post" class="form form-horizontal">
         {% csrf_token %}

--- a/netbox_dns/templates/netbox_dns/zone_record.html
+++ b/netbox_dns/templates/netbox_dns/zone_record.html
@@ -45,7 +45,7 @@
       {% endif %}
 
       {# Object table controls #}
-      {% if netbox_version < '3.1.2' %}
+      {% if settings.VERSION < '3.1.2' %}
         {% include 'inc/table_controls.html' with table_modal="ZoneRecordTable_config" %}
       {% else %}
         {% include 'inc/table_controls_htmx.html' with table_modal="ZoneRecordTable_config" %}

--- a/netbox_dns/templates/netbox_dns/zone_record.html
+++ b/netbox_dns/templates/netbox_dns/zone_record.html
@@ -45,7 +45,11 @@
       {% endif %}
 
       {# Object table controls #}
-      {% include 'inc/table_controls.html' with table_modal="ZoneRecordTable_config" %}
+      {% if netbox_version < '3.1.2' %}
+        {% include 'inc/table_controls.html' with table_modal="ZoneRecordTable_config" %}
+      {% else %}
+        {% include 'inc/table_controls_htmx.html' with table_modal="ZoneRecordTable_config" %}
+      {% endif %}
 
       <form method="post" class="form form-horizontal">
         {% csrf_token %}

--- a/netbox_dns/views.py
+++ b/netbox_dns/views.py
@@ -42,6 +42,12 @@ class ZoneListView(generic.ObjectListView):
     table = ZoneTable
     template_name = "netbox_dns/object_list.html"
 
+    def extra_context(self):
+        return {
+            "netbox_version": settings.VERSION,
+        }
+
+
 
 class ZoneView(generic.ObjectView):
     """Display Zone details"""
@@ -150,6 +156,12 @@ class NameServerListView(generic.ObjectListView):
     table = NameServerTable
     template_name = "netbox_dns/object_list.html"
 
+    def extra_context(self):
+        return {
+            "netbox_version": settings.VERSION,
+        }
+
+
 
 class NameServerView(generic.ObjectView):
     """Display NameServer details"""
@@ -218,6 +230,12 @@ class RecordListView(generic.ObjectListView):
     filterset_form = RecordFilterForm
     table = RecordTable
     template_name = "netbox_dns/record_list.html"
+
+    def extra_context(self):
+        return {
+            "netbox_version": settings.VERSION,
+        }
+
 
 
 class ManagedRecordListView(generic.ObjectListView):

--- a/netbox_dns/views.py
+++ b/netbox_dns/views.py
@@ -1,5 +1,3 @@
-from django.conf import settings
-
 from netbox.views import generic
 from netbox_dns.filters import NameServerFilter, RecordFilter, ZoneFilter
 from netbox_dns.forms import (
@@ -42,11 +40,6 @@ class ZoneListView(generic.ObjectListView):
     table = ZoneTable
     template_name = "netbox_dns/object_list.html"
 
-    def extra_context(self):
-        return {
-            "netbox_version": settings.VERSION,
-        }
-
 
 class ZoneView(generic.ObjectView):
     """Display Zone details"""
@@ -59,7 +52,6 @@ class ZoneView(generic.ObjectView):
         return {
             "nameserver_warnings": ns_warnings,
             "nameserver_errors": ns_errors,
-            "netbox_version": settings.VERSION,
         }
 
 
@@ -155,11 +147,6 @@ class NameServerListView(generic.ObjectListView):
     table = NameServerTable
     template_name = "netbox_dns/object_list.html"
 
-    def extra_context(self):
-        return {
-            "netbox_version": settings.VERSION,
-        }
-
 
 class NameServerView(generic.ObjectView):
     """Display NameServer details"""
@@ -184,7 +171,6 @@ class NameServerView(generic.ObjectView):
                 "delete": delete_zone,
             },
             "model": Zone,
-            "netbox_version": settings.VERSION,
         }
 
 
@@ -229,11 +215,6 @@ class RecordListView(generic.ObjectListView):
     table = RecordTable
     template_name = "netbox_dns/record_list.html"
 
-    def extra_context(self):
-        return {
-            "netbox_version": settings.VERSION,
-        }
-
 
 class ManagedRecordListView(generic.ObjectListView):
     queryset = Record.objects.filter(managed=True)
@@ -247,11 +228,6 @@ class RecordView(generic.ObjectView):
     """Display Zone details"""
 
     queryset = Record.objects.all()
-
-    def get_extra_context(self, request, instance):
-        return {
-            "netbox_version": settings.VERSION,
-        }
 
 
 class RecordEditView(generic.ObjectEditView):

--- a/netbox_dns/views.py
+++ b/netbox_dns/views.py
@@ -48,7 +48,6 @@ class ZoneListView(generic.ObjectListView):
         }
 
 
-
 class ZoneView(generic.ObjectView):
     """Display Zone details"""
 
@@ -162,7 +161,6 @@ class NameServerListView(generic.ObjectListView):
         }
 
 
-
 class NameServerView(generic.ObjectView):
     """Display NameServer details"""
 
@@ -235,7 +233,6 @@ class RecordListView(generic.ObjectListView):
         return {
             "netbox_version": settings.VERSION,
         }
-
 
 
 class ManagedRecordListView(generic.ObjectListView):


### PR DESCRIPTION
NetBox 3.1.2 has breaking changes. This PR should fix them.

table controls template location changed from `inc/table_controls.html` to `inc/table_controls_htmx.html`. fixes #112 

@peteeckel can you review my PR please.