### PR TITLE
API Fix: exact match record name by default

### DIFF
--- a/netbox_dns/filters.py
+++ b/netbox_dns/filters.py
@@ -67,9 +67,6 @@ class RecordFilter(PrimaryModelFilterSet):
         choices=Record.CHOICES,
         null_value=None,
     )
-    name = django_filters.CharFilter(
-        lookup_expr="icontains",
-    )
     value = django_filters.CharFilter(
         lookup_expr="icontains",
     )


### PR DESCRIPTION
Problem was: 
When I search `/api/plugins/netbox-dns/records/?zone_id=1&type=PTR&name=11` I don't want to match the reverse record for 111.
The same applies forward:
When I search `/api/plugins/netbox-dns/records/?zone_id=1&type=A&name=foo` I don't want to match the A record for `foobar.domain.tld`.
By removing the `icontains` filter, the default Netbox filters are applied, which means an exact match by default.
When you want back the old behaviour (after this change is merged) you can query like this:
`/api/plugins/netbox-dns/records/?zone_id=1&type=A&name__ic=foo`