### PR TITLE
Do not load the deprecated view_helpers template code

### DIFF
--- a/netbox_dns/templates/netbox_dns/nameserver.html
+++ b/netbox_dns/templates/netbox_dns/nameserver.html
@@ -2,7 +2,6 @@
 {% load helpers %}
 {% load plugins %}
 {% load render_table from django_tables2 %}
-{% load view_helpers %}
 {% load perms %}
 
 {% block content %}

--- a/netbox_dns/templates/netbox_dns/record.html
+++ b/netbox_dns/templates/netbox_dns/record.html
@@ -2,7 +2,6 @@
 {% load helpers %}
 {% load plugins %}
 {% load render_table from django_tables2 %}
-{% load view_helpers %}
 {% load perms %}
 
 {% block controls %}

--- a/netbox_dns/templates/netbox_dns/zone_base.html
+++ b/netbox_dns/templates/netbox_dns/zone_base.html
@@ -2,7 +2,6 @@
 {% load helpers %}
 {% load plugins %}
 {% load render_table from django_tables2 %}
-{% load view_helpers %}
 {% load perms %}
 
 {% block extra_controls %}


### PR DESCRIPTION
fixes #130 

Simple fix: Just removed the incriminated load statements.