### PR TITLE
Fix immutable object lists (managed records)

### DIFF
--- a/netbox_dns/tables/record.py
+++ b/netbox_dns/tables/record.py
@@ -1,6 +1,12 @@
 import django_tables2 as tables
 
-from netbox.tables import ChoiceFieldColumn, NetBoxTable, ToggleColumn, TagColumn
+from netbox.tables import (
+    ChoiceFieldColumn,
+    NetBoxTable,
+    ToggleColumn,
+    TagColumn,
+    ActionsColumn,
+)
 
 from netbox_dns.models import Record
 
@@ -70,6 +76,7 @@ class ManagedRecordTable(RecordBaseTable):
         verbose_name="Address Record",
         linkify=True,
     )
+    actions = ActionsColumn(actions=("changelog",))
 
     class Meta(NetBoxTable.Meta):
         model = Record
@@ -126,6 +133,7 @@ class ZoneManagedRecordTable(RecordBaseTable):
         verbose_name="Address Record",
         linkify=True,
     )
+    actions = ActionsColumn(actions=("changelog",))
 
     class Meta(NetBoxTable.Meta):
         model = Record

--- a/netbox_dns/templates/netbox_dns/managed_record_list.html
+++ b/netbox_dns/templates/netbox_dns/managed_record_list.html
@@ -1,0 +1,3 @@
+{% extends 'generic/object_list.html' %}
+
+{% block title %}Managed Records{% endblock %}


### PR DESCRIPTION
fixes #132 

This PR contains fixes for the issues with managed record lists.

Essentially, all buttons except "Export" have been removed from the page, and `ManagedRecordTable` and `ZoneManagedRecordTable` have been modified so they only show supported actions in their `ActionColumn`.

This PR should be merged after #139.