### PR TITLE
Re-add the q() filter for name server objects

### DIFF
--- a/netbox_dns/filters.py
+++ b/netbox_dns/filters.py
@@ -34,10 +34,21 @@ class NameServerFilter(PrimaryModelFilterSet):
     """Filter capabilities for NameServer instances."""
 
     tag = TagFilter()
+    q = django_filters.CharFilter(
+        method="search",
+        label="Search",
+    )
 
     class Meta:
         model = NameServer
         fields = ("name",)
+
+    def search(self, queryset, name, value):
+        """Perform the filtered search."""
+        if not value.strip():
+            return queryset
+        qs_filter = Q(name__icontains=value)
+        return queryset.filter(qs_filter)
 
 
 class RecordFilter(PrimaryModelFilterSet):


### PR DESCRIPTION
fixes #134

During code cleanup for some objects, the q() Filter for NameServer objects was removed as there did not seem a need for having two filters for case-insensitive substrings on an object having only its name as a meaningful search criteria.

There is, however, still a need for q() as it is used in "Quick Search", so the functionality needs to be restored.