### PR TITLE
Make the record type case insensitive in bulk import

### DIFF
--- a/netbox_dns/forms/record.py
+++ b/netbox_dns/forms/record.py
@@ -203,6 +203,9 @@ class RecordCSVForm(NetBoxModelCSVForm):
 
         return None
 
+    def clean_type(self):
+        return self.cleaned_data["type"].upper()
+
     class Meta:
         model = Record
         fields = ("zone", "type", "name", "value", "ttl", "disable_ptr")


### PR DESCRIPTION
Convert the record type to uppercase on Record bulk import.

fixes #167