### PR TITLE
Truncate the value field in record tables

### DIFF
--- a/netbox_dns/tables/record.py
+++ b/netbox_dns/tables/record.py
@@ -20,6 +20,9 @@ class RecordBaseTable(NetBoxTable):
     name = tables.Column(
         linkify=True,
     )
+    value = tables.TemplateColumn(
+        template_code="{{ value|truncatechars:64 }}",
+    )
     ttl = tables.Column(
         verbose_name="TTL",
     )


### PR DESCRIPTION
This PR truncates the "value" field in record tables to 64 characters, which should be sufficient in most situations. The full value of any record field is still visible in the detail view.

fixes #169