### PR TITLE
Validate records using dnspython

### DIFF
--- a/netbox_dns/forms/view.py
+++ b/netbox_dns/forms/view.py
@@ -6,9 +6,9 @@ from netbox.forms import (
     NetBoxModelCSVForm,
     NetBoxModelForm,
 )
-from netbox_dns.models import View
-
 from utilities.forms import TagFilterField
+
+from netbox_dns.models import View
 
 
 class ViewForm(NetBoxModelForm):

--- a/netbox_dns/models.py
+++ b/netbox_dns/models.py
@@ -2,6 +2,7 @@ import ipaddress
 
 from math import ceil
 from datetime import datetime
+from dns import rdatatype
 
 from django.core.validators import MinValueValidator, MaxValueValidator
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
@@ -491,67 +492,23 @@ class RecordManager(models.Manager.from_queryset(RestrictedQuerySet)):
         )
 
 
+def initialize_choice_names(cls):
+    for choice in cls.CHOICES:
+        setattr(cls, choice[0], choice[0])
+    return cls
+
+@initialize_choice_names
 class RecordTypeChoices(ChoiceSet):
-    key = "Record.type"
-
-    A = "A"
-    AAAA = "AAAA"
-    CNAME = "CNAME"
-    MX = "MX"
-    TXT = "TXT"
-    NS = "NS"
-    SOA = "SOA"
-    SRV = "SRV"
-    PTR = "PTR"
-    SPF = "SPF"
-    CAA = "CAA"
-    DS = "DS"
-    SSHFP = "SSHFP"
-    TLSA = "TLSA"
-    AFSDB = "AFSDB"
-    APL = "APL"
-    DNSKEY = "DNSKEY"
-    CDNSKEY = "CDNSKEY"
-    CERT = "CERT"
-    DCHID = "DCHID"
-    DNAME = "DNAME"
-    HIP = "HIP"
-    IPSECKEY = "IPSECKEY"
-    LOC = "LOC"
-    NAPTR = "NAPTR"
-    NSEC = "NSEC"
-    RRSIG = "RRSIG"
-    RP = "RP"
-
     CHOICES = [
-        (A, A),
-        (AAAA, AAAA),
-        (CNAME, CNAME),
-        (MX, MX),
-        (TXT, TXT),
-        (SOA, SOA),
-        (NS, NS),
-        (SRV, SRV),
-        (PTR, PTR),
-        (SPF, SPF),
-        (CAA, CAA),
-        (DS, DS),
-        (SSHFP, SSHFP),
-        (TLSA, TLSA),
-        (AFSDB, AFSDB),
-        (APL, APL),
-        (DNSKEY, DNSKEY),
-        (CDNSKEY, CDNSKEY),
-        (CERT, CERT),
-        (DCHID, DCHID),
-        (DNAME, DNAME),
-        (HIP, HIP),
-        (IPSECKEY, IPSECKEY),
-        (LOC, LOC),
-        (NAPTR, NAPTR),
-        (NSEC, NSEC),
-        (RRSIG, RRSIG),
-        (RP, RP),
+        (rdtype.name, rdtype.name)
+        for rdtype in sorted(rdatatype.RdataType, key=lambda a: a.name)
+    ]
+
+
+@initialize_choice_names
+class RecordClassChoices(ChoiceSet):
+    CHOICES = [
+        (rdclass.name, rdclass.name) for rdclass in sorted(rdataclass.RdataClass)
     ]
 
 

--- a/netbox_dns/models.py
+++ b/netbox_dns/models.py
@@ -2,7 +2,7 @@ import ipaddress
 
 from math import ceil
 from datetime import datetime
-from dns import rdatatype
+from dns import rdatatype, rdataclass
 
 from django.core.validators import MinValueValidator, MaxValueValidator
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
@@ -497,6 +497,7 @@ def initialize_choice_names(cls):
         setattr(cls, choice[0], choice[0])
     return cls
 
+
 @initialize_choice_names
 class RecordTypeChoices(ChoiceSet):
     CHOICES = [
@@ -510,6 +511,11 @@ class RecordClassChoices(ChoiceSet):
     CHOICES = [
         (rdclass.name, rdclass.name) for rdclass in sorted(rdataclass.RdataClass)
     ]
+
+
+@initialize_choice_names
+class RecordClassChoices(ChoiceSet):
+    CHOICES = [(rdclass.name, rdclass.name) for rdclass in rdataclass.RdataClass]
 
 
 class Record(NetBoxModel):

--- a/netbox_dns/tests/custom.py
+++ b/netbox_dns/tests/custom.py
@@ -14,8 +14,8 @@ class ModelViewTestCase(NetBoxModelViewTestCase):
         Return the base format for a URL for the test's model. Override this to test for a model which belongs
         to a different app (e.g. testing Interfaces within the virtualization app).
         """
-        return "plugins:{}:{}_{{}}".format(
-            self.model._meta.app_label, self.model._meta.model_name
+        return (
+            f"plugins:{self.model._meta.app_label}:{self.model._meta.model_name}_{{}}"
         )
 
 

--- a/netbox_dns/tests/record/test_validation.py
+++ b/netbox_dns/tests/record/test_validation.py
@@ -1,0 +1,178 @@
+from django.test import TestCase
+from django.core.exceptions import ValidationError
+
+from netbox_dns.models import Zone, Record, RecordTypeChoices, NameServer
+
+
+class RecordValidationTest(TestCase):
+
+    zone_data = {
+        "default_ttl": 86400,
+        "soa_rname": "hostmaster.example.com",
+        "soa_refresh": 172800,
+        "soa_retry": 7200,
+        "soa_expire": 2592000,
+        "soa_ttl": 86400,
+        "soa_minimum": 3600,
+        "soa_serial": 1,
+    }
+
+    record_data = {
+        "ttl": 86400,
+    }
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.nameserver = NameServer.objects.create(name="ns1.example.com")
+        cls.zones = [
+            Zone(name="zone1.example.com", **cls.zone_data, soa_mname=cls.nameserver),
+            Zone(name="1.0.10.in-addr.arpa", **cls.zone_data, soa_mname=cls.nameserver),
+            Zone(
+                name="1.0.0.0.f.e.e.b.d.a.e.d.0.8.e.f.ip6.arpa",
+                **cls.zone_data,
+                soa_mname=cls.nameserver,
+            ),
+        ]
+        Zone.objects.bulk_create(cls.zones)
+
+    def test_create_record_validation_ok(self):
+        f_zone = self.zones[0]
+
+        ok_records = [
+            {"name": "test1", "type": RecordTypeChoices.A, "value": "10.0.1.42"},
+            {"name": "test2", "type": RecordTypeChoices.A, "value": "10.0.2.42"},
+            {
+                "name": "test3",
+                "type": RecordTypeChoices.AAAA,
+                "value": "fe80:dead:beef::1:42",
+            },
+            {
+                "name": "test4",
+                "type": RecordTypeChoices.AAAA,
+                "value": "fe80:dead:beef::2:42",
+            },
+            {
+                "name": "test5",
+                "type": RecordTypeChoices.MX,
+                "value": "10 mx1.example.com",
+            },
+            {
+                "name": "test6",
+                "type": RecordTypeChoices.MX,
+                "value": "10 mx1.example.com.",
+            },
+            {
+                "name": "test7",
+                "type": RecordTypeChoices.SOA,
+                "value": "(ns1.example.com. hostmaster.example.com. 1651498477 172800 7200 2592000 3600)",
+            },
+            {
+                "name": "test8",
+                "type": RecordTypeChoices.CAA,
+                "value": "1 issue example.org",
+            },
+            {"name": "test9", "type": RecordTypeChoices.CNAME, "value": "test1"},
+        ]
+
+        for record in ok_records:
+            f_record = Record(
+                zone=f_zone,
+                **record,
+                **self.record_data,
+            )
+            f_record.save()
+
+    def test_create_record_validation_fail(self):
+        f_zone = self.zones[0]
+
+        broken_records = [
+            {"name": "test1", "type": RecordTypeChoices.A, "value": "1.1.1.1.1"},
+            {"name": "test2", "type": RecordTypeChoices.A, "value": "1.1.1"},
+            {"name": "test3", "type": RecordTypeChoices.A, "value": "1.1.1.256"},
+            {
+                "name": "test4",
+                "type": RecordTypeChoices.A,
+                "value": "fe80:dead:beef:1:42:1111:2222:3333:4444",
+            },
+            {
+                "name": "test5",
+                "type": RecordTypeChoices.A,
+                "value": "fe80:dead:beef:1:42:1111:2222",
+            },
+            {
+                "name": "test6",
+                "type": RecordTypeChoices.A,
+                "value": "fe80:dead:beer:1:42:1111:2222:3333",
+            },
+            {"name": "test7", "type": RecordTypeChoices.AAAA, "value": "1.1.1.1.1"},
+            {"name": "test8", "type": RecordTypeChoices.AAAA, "value": "1.1.1"},
+            {"name": "test9", "type": RecordTypeChoices.AAAA, "value": "1.1.1.256"},
+            {
+                "name": "test10",
+                "type": RecordTypeChoices.AAAA,
+                "value": "fe80:dead:beef:42:1111:2222:3333:4444:5555",
+            },
+            {
+                "name": "test11",
+                "type": RecordTypeChoices.AAAA,
+                "value": "fe80:dead:beef:42:1111:2222:3333",
+            },
+            {
+                "name": "test12",
+                "type": RecordTypeChoices.AAAA,
+                "value": "fe80:dead:beer:42:1111:2222:3333:4444",
+            },
+            {
+                "name": "test13",
+                "type": RecordTypeChoices.MX,
+                "value": "1000000 mx1.example.com",
+            },
+            {
+                "name": "test13",
+                "type": RecordTypeChoices.MX,
+                "value": "1000000 1.1.1.1",
+            },
+            {
+                "name": "test14",
+                "type": RecordTypeChoices.SOA,
+                "value": "(ns1.example.com. hostmaster.example.com. 1651498477 172800 7200 2592000)",
+            },
+            {
+                "name": "test15",
+                "type": RecordTypeChoices.SOA,
+                "value": "(ns1.example.com. 1651498477 172800 7200 2592000 3600)",
+            },
+            {
+                "name": "test16",
+                "type": RecordTypeChoices.SOA,
+                "value": "(ns1.example.com. hostmaster.example.com. -1 172800 7200 2592000 3600)",
+            },
+            {
+                "name": "test17",
+                "type": RecordTypeChoices.SOA,
+                "value": "(ns1.example.com. hostmaster.example.com. claptrap 172800 7200 2592000 3600)",
+            },
+            {"name": "test18", "type": RecordTypeChoices.CAA, "value": "1"},
+            {"name": "test19", "type": RecordTypeChoices.CAA, "value": "issue"},
+            {"name": "test20", "type": RecordTypeChoices.CAA, "value": "1 issue"},
+            {
+                "name": "test21",
+                "type": RecordTypeChoices.CAA,
+                "value": "1 issue example.org claptrap",
+            },
+            {
+                "name": "test22",
+                "type": RecordTypeChoices.CNAME,
+                "value": "test1 claptrap",
+            },
+        ]
+
+        for record in broken_records:
+            f_record = Record(
+                zone=f_zone,
+                **record,
+                **self.record_data,
+            )
+
+            with self.assertRaises(ValidationError):
+                f_record.save()

--- a/netbox_dns/tests/zone/test_api.py
+++ b/netbox_dns/tests/zone/test_api.py
@@ -32,7 +32,7 @@ class ZoneTest(
         "soa_expire": 2592000,
         "soa_ttl": 86400,
         "soa_minimum": 3600,
-        "soa_serial_auto": False,
+        "soa_serial_auto": True,
     }
 
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ exclude = ["netbox_dns/tests/*"]
 keywords = ["netbox", "netbox-plugin", "dns"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
+dnspython = "^2.2.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
This PR modifies the way records are validated before saving.

Up to now, only address records have been validated by checking if their value was a valid IPv4/IPv6 address. All other record types essentially were saved unchecked.

With this PR, validation of records was moved from forms to the model (which gives a a more thorough way of making sure only validated data go into the database and promptly broke one of the old tests that created an illegal SOA record), and all records that dnspython can validate are now validated to be compliant with the standards (at least as far as dnspython can check this). 

In addition, the list of available record types is now generated from the record types dnspython knows, which adds some additional record types to the supported types and makes sure new types are included automatically.

fixes #174