### PR TITLE
Add validation for CNAME and singleton Record objects

### DIFF
--- a/netbox_dns/models.py
+++ b/netbox_dns/models.py
@@ -511,6 +511,9 @@ class RecordTypeChoices(ChoiceSet):
         (rdtype.name, rdtype.name)
         for rdtype in sorted(rdatatype.RdataType, key=lambda a: a.name)
     ]
+    SINGLETONS = [
+        rdtype.name for rdtype in rdatatype.RdataType if rdatatype.is_singleton(rdtype)
+    ]
 
 
 @initialize_choice_names
@@ -709,6 +712,33 @@ class Record(NetBoxModel):
             raise ValidationError(
                 {"value": f"Record value {self.value} is malformed: {exc}."}
             ) from None
+
+        records = Record.objects.filter(name=self.name, zone=self.zone).exclude(
+            pk=self.pk
+        )
+
+        if self.type == RecordTypeChoices.CNAME:
+            if records.exists():
+                raise ValidationError(
+                    {
+                        "type": f"There is already a record for name {self.name} in zone {self.zone}, CNAME is not allowed."
+                    }
+                ) from None
+
+        elif records.filter(type=RecordTypeChoices.CNAME).exists():
+            raise ValidationError(
+                {
+                    "type": f"There is already a CNAME record for name {self.name} in zone {self.zone}, no other record allowed."
+                }
+            ) from None
+
+        elif self.type in RecordTypeChoices.SINGLETONS:
+            if records.filter(type=self.type).exists():
+                raise ValidationError(
+                    {
+                        "type": f"There is already a {self.type} record for name {self.name} in zone {self.zone}, more than one are not allowed."
+                    }
+                ) from None
 
     def save(self, *args, **kwargs):
         self.full_clean()

--- a/netbox_dns/tests/record/test_validation.py
+++ b/netbox_dns/tests/record/test_validation.py
@@ -176,3 +176,84 @@ class RecordValidationTest(TestCase):
 
             with self.assertRaises(ValidationError):
                 f_record.save()
+
+    def test_name_and_cname(self):
+        f_zone = self.zones[0]
+
+        name1 = "test1"
+        name2 = "test2"
+        address = "fe80:dead:beef:1::42"
+
+        f_record1 = Record(
+            zone=f_zone,
+            name=name1,
+            type=RecordTypeChoices.AAAA,
+            value=address,
+            **self.record_data,
+        )
+        f_record1.save()
+
+        f_record2 = Record(
+            zone=f_zone,
+            name=name1,
+            type=RecordTypeChoices.CNAME,
+            value=name2,
+            **self.record_data,
+        )
+
+        with self.assertRaises(ValidationError):
+            f_record2.save()
+
+    def test_cname_and_name(self):
+        f_zone = self.zones[0]
+
+        name1 = "test1"
+        name2 = "test2"
+        address = "fe80:dead:beef:1::42"
+
+        f_record1 = Record(
+            zone=f_zone,
+            name=name1,
+            type=RecordTypeChoices.CNAME,
+            value=name2,
+            **self.record_data,
+        )
+        f_record1.save()
+
+        f_record2 = Record(
+            zone=f_zone,
+            name=name1,
+            type=RecordTypeChoices.AAAA,
+            value=address,
+            **self.record_data,
+        )
+
+        with self.assertRaises(ValidationError):
+            f_record2.save()
+
+    def test_double_singletons(self):
+        f_zone = self.zones[1]
+
+        name1 = "test1"
+        name2 = "test2"
+        name3 = "test3"
+
+        f_record1 = Record(
+            zone=f_zone,
+            name=name1,
+            type=RecordTypeChoices.DNAME,
+            value=name2,
+            **self.record_data,
+        )
+        f_record1.save()
+
+        f_record2 = Record(
+            zone=f_zone,
+            name=name1,
+            type=RecordTypeChoices.DNAME,
+            value=name3,
+            **self.record_data,
+        )
+
+        with self.assertRaises(ValidationError):
+            f_record2.save()


### PR DESCRIPTION
There are three checks that are performed:

- When a CNAME record is added to a zone that already has another record with the same name, the CNAME creation is denied.
- When a record with any type is added to a zone that already has a CNAME with the same name, the new record creation is denied.
- When a record with a singleton type is added to a zone that already has another record with the same type and name, the singleton record creation is refused.

This avoids creating zones that cannot be loaded by name servers.

fixes #180
fixes #72