### PR TITLE
Remove PTR record when record type changes from A/AAAA to something else

### DIFF
--- a/netbox_dns/models.py
+++ b/netbox_dns/models.py
@@ -748,6 +748,9 @@ class Record(NetBoxModel):
 
         if self.type in (RecordTypeChoices.A, RecordTypeChoices.AAAA):
             self.update_ptr_record()
+        elif self.ptr_record is not None:
+            self.ptr_record.delete()
+            self.ptr_record = None
 
         if self.address_conflicts:
             raise ValidationError(


### PR DESCRIPTION
This was kept undetected for a while ... though very easy to fix. Tests added.

fixes #188