### PR TITLE
Allow multiple PTR records for the same address

### DIFF
--- a/docs/using_netbox_dns.md
+++ b/docs/using_netbox_dns.md
@@ -267,7 +267,7 @@ For the address record types A and AAAA, Netbox DNS can automatically generate a
 
 If, for instance, there is a zone `0.0.10.in-addr.arpa` is defined in Netbox DNS and an address record is created in a forward zone `example.com` with the address `10.0.0.1`, the corresponding PTR record will be created in the former zone as the reverse RR name for the IPv4 address `10.0.0.1` is `1.0.0.10.in-addr.arpa`.
 
-If another A record with the same IPv4 address as its value is created, Netbox DNS will not accept it as the PTR record must be unique. In that case, the "Disable PTR" flag must be set for one of the A records.
+When an A record is created for which a PTR record is not necessary or desired, the "Disable PTR" option can be used to inhibit the creation of the corresponding PTR record even if a reverse zone matching the address is present.
 
 If the reverse zone does not exist in Netbox DNS, it will not be created automatically as it is not certain that the authority for that zone lies with the user. If, however, a matching reverse zone is created later on, the PTR records for all A or AAAA records in Netbox DNS that match the new reverse zone will be created automatically (unless "Disable PTR" is set for a record).
 

--- a/netbox_dns/tests/record/test_auto_ptr.py
+++ b/netbox_dns/tests/record/test_auto_ptr.py
@@ -1,7 +1,6 @@
 import ipaddress
 
 from django.test import TestCase
-from django.core.exceptions import ValidationError
 
 
 from netbox_dns.models import NameServer, Record, RecordTypeChoices, Zone
@@ -118,30 +117,32 @@ class AutoPTRTest(TestCase):
                 name=reverse_name(address, r_zone),
             )
 
-    def test_create_duplicate_ipv4(self):
+    def test_create_multiple_ipv4(self):
         f_zone = self.zones[0]
+        r_zone = self.zones[1]
 
-        name1 = "test1"
-        name2 = "test2"
+        names = ["test1", "test2", "test3", "test4"]
         address = "10.0.1.42"
 
-        f_record1 = Record(
-            zone=f_zone,
-            name=name1,
-            type=RecordTypeChoices.A,
-            value=address,
-            **self.record_data,
-        )
-        f_record1.save()
+        for name in names:
+            f_record = Record(
+                zone=f_zone,
+                name=name,
+                type=RecordTypeChoices.A,
+                value=address,
+                **self.record_data,
+            )
+            f_record.save()
 
-        f_record2 = Record(
-            zone=f_zone,
-            name=name2,
-            type=RecordTypeChoices.A,
-            value=address,
-            **self.record_data,
+        r_records = Record.objects.filter(
+            type=RecordTypeChoices.PTR,
+            zone=r_zone,
+            name=reverse_name(address, r_zone),
         )
-        self.assertRaises(ValidationError, f_record2.save)
+        for r_record in r_records:
+            self.assertTrue(
+                r_record.value in [f"{name}.{f_zone.name}." for name in names]
+            )
 
     def test_create_duplicate_ipv4_disable_ptr_1(self):
         f_zone = self.zones[0]
@@ -491,30 +492,32 @@ class AutoPTRTest(TestCase):
                 name=reverse_name(address, r_zone),
             )
 
-    def test_create_duplicate_ipv6(self):
+    def test_create_multiple_ipv6(self):
         f_zone = self.zones[0]
+        r_zone = self.zones[6]
 
-        name1 = "test1"
-        name2 = "test2"
+        names = ["test1", "test2", "test3", "test4"]
         address = "fe80:dead:beef:1::42"
 
-        f_record1 = Record(
-            zone=f_zone,
-            name=name1,
-            type=RecordTypeChoices.AAAA,
-            value=address,
-            **self.record_data,
-        )
-        f_record1.save()
+        for name in names:
+            f_record = Record(
+                zone=f_zone,
+                name=name,
+                type=RecordTypeChoices.AAAA,
+                value=address,
+                **self.record_data,
+            )
+            f_record.save()
 
-        f_record2 = Record(
-            zone=f_zone,
-            name=name2,
-            type=RecordTypeChoices.AAAA,
-            value=address,
-            **self.record_data,
+        r_records = Record.objects.filter(
+            type=RecordTypeChoices.PTR,
+            zone=r_zone,
+            name=reverse_name(address, r_zone),
         )
-        self.assertRaises(ValidationError, f_record2.save)
+        for r_record in r_records:
+            self.assertTrue(
+                r_record.value in [f"{name}.{f_zone.name}." for name in names]
+            )
 
     def test_create_duplicate_ipv6_disable_ptr_1(self):
         f_zone = self.zones[0]

--- a/netbox_dns/tests/view/test_zone.py
+++ b/netbox_dns/tests/view/test_zone.py
@@ -394,7 +394,7 @@ class ZoneMoveTest(TestCase):
                 type=RecordTypeChoices.PTR, name=reverse_name(address, r_zone)
             )
 
-    def test_ipv4_add_view_record_conflict(self):
+    def test_ipv4_add_view_multiple_ptr(self):
         f_zone1 = self.zones[1]
         f_zone2 = Zone(
             name="zone2.example.com",
@@ -403,33 +403,35 @@ class ZoneMoveTest(TestCase):
             view=None,
         )
         f_zone2.save()
+        r_zone = self.zones[3]
 
         name = "test1"
         address = "10.0.1.42"
 
-        f_record1 = Record(
-            zone=f_zone1,
-            name=name,
-            type=RecordTypeChoices.A,
-            value=address,
-            **self.record_data,
-        )
-        f_record1.save()
-
-        f_record2 = Record(
-            zone=f_zone2,
-            name=name,
-            type=RecordTypeChoices.A,
-            value=address,
-            **self.record_data,
-        )
-        f_record2.save()
+        for f_zone in (f_zone1, f_zone2):
+            f_record = Record(
+                zone=f_zone,
+                name=name,
+                type=RecordTypeChoices.A,
+                value=address,
+                **self.record_data,
+            )
+            f_record.save()
 
         f_zone2.view = self.views[0]
-        with self.assertRaises(ValidationError):
-            f_zone2.save()
+        f_zone2.save()
 
-    def test_ipv4_remove_view_record_conflict(self):
+        r_records = Record.objects.filter(
+            type=RecordTypeChoices.PTR, zone=r_zone, name=reverse_name(address, r_zone)
+        )
+
+        for r_record in r_records:
+            self.assertTrue(
+                r_record.value
+                in [f"{name}.{f_zone.name}." for f_zone in (f_zone1, f_zone2)]
+            )
+
+    def test_ipv4_remove_view_multiple_ptr(self):
         f_zone1 = self.zones[0]
         f_zone2 = Zone(
             name="zone2.example.com",
@@ -438,33 +440,35 @@ class ZoneMoveTest(TestCase):
             view=self.views[1],
         )
         f_zone2.save()
+        r_zone = self.zones[2]
 
         name = "test1"
         address = "10.0.1.42"
 
-        f_record1 = Record(
-            zone=f_zone1,
-            name=name,
-            type=RecordTypeChoices.A,
-            value=address,
-            **self.record_data,
-        )
-        f_record1.save()
-
-        f_record2 = Record(
-            zone=f_zone2,
-            name=name,
-            type=RecordTypeChoices.A,
-            value=address,
-            **self.record_data,
-        )
-        f_record2.save()
+        for f_zone in (f_zone1, f_zone2):
+            f_record = Record(
+                zone=f_zone,
+                name=name,
+                type=RecordTypeChoices.A,
+                value=address,
+                **self.record_data,
+            )
+            f_record.save()
 
         f_zone2.view = None
-        with self.assertRaises(ValidationError):
-            f_zone2.save()
+        f_zone2.save()
 
-    def test_ipv4_change_view_record_conflict(self):
+        r_records = Record.objects.filter(
+            type=RecordTypeChoices.PTR, zone=r_zone, name=reverse_name(address, r_zone)
+        )
+
+        for r_record in r_records:
+            self.assertTrue(
+                r_record.value
+                in [f"{name}.{f_zone.name}." for f_zone in (f_zone1, f_zone2)]
+            )
+
+    def test_ipv4_change_view_multiple_ptr(self):
         f_zone1 = self.zones[1]
         f_zone2 = Zone(
             name="zone2.example.com",
@@ -473,31 +477,33 @@ class ZoneMoveTest(TestCase):
             view=self.views[1],
         )
         f_zone2.save()
+        r_zone = self.zones[3]
 
         name = "test1"
         address = "10.0.1.42"
 
-        f_record1 = Record(
-            zone=f_zone1,
-            name=name,
-            type=RecordTypeChoices.A,
-            value=address,
-            **self.record_data,
-        )
-        f_record1.save()
-
-        f_record2 = Record(
-            zone=f_zone2,
-            name=name,
-            type=RecordTypeChoices.A,
-            value=address,
-            **self.record_data,
-        )
-        f_record2.save()
+        for f_zone in (f_zone1, f_zone2):
+            f_record = Record(
+                zone=f_zone,
+                name=name,
+                type=RecordTypeChoices.A,
+                value=address,
+                **self.record_data,
+            )
+            f_record.save()
 
         f_zone2.view = self.views[0]
-        with self.assertRaises(ValidationError):
-            f_zone2.save()
+        f_zone2.save()
+
+        r_records = Record.objects.filter(
+            type=RecordTypeChoices.PTR, zone=r_zone, name=reverse_name(address, r_zone)
+        )
+
+        for r_record in r_records:
+            self.assertTrue(
+                r_record.value
+                in [f"{name}.{f_zone.name}." for f_zone in (f_zone1, f_zone2)]
+            )
 
     def test_ipv6_add_view_to_zone_new_ptr_added(self):
         f_zone = self.zones[0]
@@ -795,7 +801,7 @@ class ZoneMoveTest(TestCase):
                 type=RecordTypeChoices.PTR, name=reverse_name(address, r_zone)
             )
 
-    def test_ipv6_add_view_record_conflict(self):
+    def test_ipv6_add_view_multiple_ptr(self):
         f_zone1 = self.zones[1]
         f_zone2 = Zone(
             name="zone2.example.com",
@@ -804,33 +810,35 @@ class ZoneMoveTest(TestCase):
             view=None,
         )
         f_zone2.save()
+        r_zone = self.zones[5]
 
         name = "test1"
         address = "fe80:dead:beef:1::42"
 
-        f_record1 = Record(
-            zone=f_zone1,
-            name=name,
-            type=RecordTypeChoices.AAAA,
-            value=address,
-            **self.record_data,
-        )
-        f_record1.save()
-
-        f_record2 = Record(
-            zone=f_zone2,
-            name=name,
-            type=RecordTypeChoices.AAAA,
-            value=address,
-            **self.record_data,
-        )
-        f_record2.save()
+        for f_zone in (f_zone1, f_zone2):
+            f_record = Record(
+                zone=f_zone,
+                name=name,
+                type=RecordTypeChoices.AAAA,
+                value=address,
+                **self.record_data,
+            )
+            f_record.save()
 
         f_zone2.view = self.views[0]
-        with self.assertRaises(ValidationError):
-            f_zone2.save()
+        f_zone2.save()
 
-    def test_ipv6_remove_view_record_conflict(self):
+        r_records = Record.objects.filter(
+            type=RecordTypeChoices.PTR, zone=r_zone, name=reverse_name(address, r_zone)
+        )
+
+        for r_record in r_records:
+            self.assertTrue(
+                r_record.value
+                in [f"{name}.{f_zone.name}." for f_zone in (f_zone1, f_zone2)]
+            )
+
+    def test_ipv6_remove_view_multiple_ptr(self):
         f_zone1 = self.zones[0]
         f_zone2 = Zone(
             name="zone2.example.com",
@@ -839,33 +847,35 @@ class ZoneMoveTest(TestCase):
             view=self.views[1],
         )
         f_zone2.save()
+        r_zone = self.zones[4]
 
         name = "test1"
         address = "fe80:dead:beef:1::42"
 
-        f_record1 = Record(
-            zone=f_zone1,
-            name=name,
-            type=RecordTypeChoices.AAAA,
-            value=address,
-            **self.record_data,
-        )
-        f_record1.save()
-
-        f_record2 = Record(
-            zone=f_zone2,
-            name=name,
-            type=RecordTypeChoices.AAAA,
-            value=address,
-            **self.record_data,
-        )
-        f_record2.save()
+        for f_zone in (f_zone1, f_zone2):
+            f_record = Record(
+                zone=f_zone,
+                name=name,
+                type=RecordTypeChoices.AAAA,
+                value=address,
+                **self.record_data,
+            )
+            f_record.save()
 
         f_zone2.view = None
-        with self.assertRaises(ValidationError):
-            f_zone2.save()
+        f_zone2.save()
 
-    def test_ipv6_change_view_record_conflict(self):
+        r_records = Record.objects.filter(
+            type=RecordTypeChoices.PTR, zone=r_zone, name=reverse_name(address, r_zone)
+        )
+
+        for r_record in r_records:
+            self.assertTrue(
+                r_record.value
+                in [f"{name}.{f_zone.name}." for f_zone in (f_zone1, f_zone2)]
+            )
+
+    def test_ipv6_change_view_multiple_ptr(self):
         f_zone1 = self.zones[1]
         f_zone2 = Zone(
             name="zone2.example.com",
@@ -874,31 +884,33 @@ class ZoneMoveTest(TestCase):
             view=self.views[1],
         )
         f_zone2.save()
+        r_zone = self.zones[4]
 
         name = "test1"
         address = "fe80:dead:beef:1::42"
 
-        f_record1 = Record(
-            zone=f_zone1,
-            name=name,
-            type=RecordTypeChoices.AAAA,
-            value=address,
-            **self.record_data,
-        )
-        f_record1.save()
-
-        f_record2 = Record(
-            zone=f_zone2,
-            name=name,
-            type=RecordTypeChoices.AAAA,
-            value=address,
-            **self.record_data,
-        )
-        f_record2.save()
+        for f_zone in (f_zone1, f_zone2):
+            f_record = Record(
+                zone=f_zone,
+                name=name,
+                type=RecordTypeChoices.AAAA,
+                value=address,
+                **self.record_data,
+            )
+            f_record.save()
 
         f_zone2.view = self.views[0]
-        with self.assertRaises(ValidationError):
-            f_zone2.save()
+        f_zone2.save()
+
+        r_records = Record.objects.filter(
+            type=RecordTypeChoices.PTR, zone=r_zone, name=reverse_name(address, r_zone)
+        )
+
+        for r_record in r_records:
+            self.assertTrue(
+                r_record.value
+                in [f"{name}.{f_zone.name}." for f_zone in (f_zone1, f_zone2)]
+            )
 
     def test_add_view_to_zone_zone_conflict(self):
         f_zone = self.zones[0]


### PR DESCRIPTION
fixes #191 

This PR changes the behaviour of NetBox DNS to allow multiple PTR records for the same address. If, for example, address records are generated like this in zone `zone1.example.com`:
```
name1    86400    IN    A    10.0.1.1
name2    86400    IN    A    10.0.1.1
```

NetBox DNS will create two matching PTR records in zone `1.0.10.in-addr.arpa.`:
```
1    86400    IN    PTR    name1.zone1.example.com.
1    86400    IN    PTR    name2.zone1.example.com.
```

Before this change, NetBox DNS would not allow the second entry in order to keep the PTR record unique, which is, however, not a requirement and restricts the use of the tool in a way that actually makes it less generally usable.

Tests and documentation have been adjusted accordingly.