### PR TITLE
Return to the list view for an object type after deleting an object

### DIFF
--- a/netbox_dns/views/nameserver.py
+++ b/netbox_dns/views/nameserver.py
@@ -53,6 +53,7 @@ class NameServerEditView(generic.ObjectEditView):
 
 class NameServerDeleteView(generic.ObjectDeleteView):
     queryset = NameServer.objects.all()
+    default_return_url = "plugins:netbox_dns:nameserver_list"
 
 
 class NameServerBulkImportView(generic.BulkImportView):

--- a/netbox_dns/views/record.py
+++ b/netbox_dns/views/record.py
@@ -48,6 +48,7 @@ class RecordEditView(generic.ObjectEditView):
 
 class RecordDeleteView(generic.ObjectDeleteView):
     queryset = Record.objects.filter(managed=False)
+    default_return_url = "plugins:netbox_dns:record_list"
 
 
 class RecordBulkImportView(generic.BulkImportView):

--- a/netbox_dns/views/view.py
+++ b/netbox_dns/views/view.py
@@ -44,6 +44,7 @@ class ViewEditView(generic.ObjectEditView):
 
 class ViewDeleteView(generic.ObjectDeleteView):
     queryset = View.objects.all()
+    default_return_url = "plugins:netbox_dns:view_list"
 
 
 class ViewBulkImportView(generic.BulkImportView):

--- a/netbox_dns/views/zone.py
+++ b/netbox_dns/views/zone.py
@@ -53,6 +53,7 @@ class ZoneDeleteView(generic.ObjectDeleteView):
     """View for deleting a Zone instance"""
 
     queryset = Zone.objects.all()
+    default_return_url = "plugins:netbox_dns:zone_list"
 
 
 class ZoneBulkImportView(generic.BulkImportView):


### PR DESCRIPTION
After deleting an object, return to the object type's associated list view.

fixes #193