### PR TITLE
Initial implementation of GraphQL support

### DIFF
--- a/netbox_dns/graphql/__init__.py
+++ b/netbox_dns/graphql/__init__.py
@@ -1,0 +1,6 @@
+from .schema import *
+
+from .view import *
+from .zone import *
+from .nameserver import *
+from .record import *

--- a/netbox_dns/graphql/nameserver.py
+++ b/netbox_dns/graphql/nameserver.py
@@ -1,0 +1,19 @@
+from graphene import ObjectType
+
+from netbox.graphql.fields import ObjectField, ObjectListField
+from netbox.graphql.types import NetBoxObjectType
+
+from netbox_dns.models import NameServer
+from netbox_dns.filters import NameServerFilter
+
+
+class NameServerType(NetBoxObjectType):
+    class Meta:
+        model = NameServer
+        fields = "__all__"
+        filterset_class = NameServerFilter
+
+
+class NameServerQuery(ObjectType):
+    nameserver = ObjectField(NameServerType)
+    nameserver_list = ObjectListField(NameServerType)

--- a/netbox_dns/graphql/record.py
+++ b/netbox_dns/graphql/record.py
@@ -1,0 +1,19 @@
+from graphene import ObjectType
+
+from netbox.graphql.fields import ObjectField, ObjectListField
+from netbox.graphql.types import NetBoxObjectType
+
+from netbox_dns.models import Record
+from netbox_dns.filters import RecordFilter
+
+
+class RecordType(NetBoxObjectType):
+    class Meta:
+        model = Record
+        fields = "__all__"
+        filterset_class = RecordFilter
+
+
+class RecordQuery(ObjectType):
+    record = ObjectField(RecordType)
+    record_list = ObjectListField(RecordType)

--- a/netbox_dns/graphql/schema.py
+++ b/netbox_dns/graphql/schema.py
@@ -1,0 +1,11 @@
+from .view import ViewQuery
+from .nameserver import NameServerQuery
+from .zone import ZoneQuery
+from .record import RecordQuery
+
+
+class Query(ViewQuery, NameServerQuery, ZoneQuery, RecordQuery):
+    pass
+
+
+schema = Query

--- a/netbox_dns/graphql/view.py
+++ b/netbox_dns/graphql/view.py
@@ -1,0 +1,19 @@
+from graphene import ObjectType
+
+from netbox.graphql.fields import ObjectField, ObjectListField
+from netbox.graphql.types import NetBoxObjectType
+
+from netbox_dns.models import View
+from netbox_dns.filters import ViewFilter
+
+
+class ViewType(NetBoxObjectType):
+    class Meta:
+        model = View
+        fields = "__all__"
+        filterset_class = ViewFilter
+
+
+class ViewQuery(ObjectType):
+    view = ObjectField(ViewType)
+    view_list = ObjectListField(ViewType)

--- a/netbox_dns/graphql/zone.py
+++ b/netbox_dns/graphql/zone.py
@@ -1,0 +1,19 @@
+from graphene import ObjectType
+
+from netbox.graphql.fields import ObjectField, ObjectListField
+from netbox.graphql.types import NetBoxObjectType
+
+from netbox_dns.models import Zone
+from netbox_dns.filters import ZoneFilter
+
+
+class ZoneType(NetBoxObjectType):
+    class Meta:
+        model = Zone
+        fields = "__all__"
+        filterset_class = ZoneFilter
+
+
+class ZoneQuery(ObjectType):
+    zone = ObjectField(ZoneType)
+    zone_list = ObjectListField(ZoneType)


### PR DESCRIPTION
fixes #197 

The only issue that unfortunately cannot be fixed that easily is that the NetBox test framework could not be convinced to test GraphQL APIs for plugins. 

This is due to the fact that the test framework is quite inflexible and actually not supported for plugins at all - so we'll need to wait until support for the test framework (which, according to the NetBox maintainers, will probably require a general cleanup that is planned for a future release) until we can use it.