### PR TITLE
Detect missing SOA serial number

### DIFF
--- a/netbox_dns/models.py
+++ b/netbox_dns/models.py
@@ -343,13 +343,6 @@ class Zone(NetBoxModel):
     def clean(self, *args, **kwargs):
         self.check_name_conflict()
 
-        if self.pk is None:
-            return
-
-        old_zone = Zone.objects.get(pk=self.pk)
-        if old_zone.view == self.view and old_zone.status == self.status:
-            return
-
     def save(self, *args, **kwargs):
         self.check_name_conflict()
 

--- a/netbox_dns/models.py
+++ b/netbox_dns/models.py
@@ -343,8 +343,15 @@ class Zone(NetBoxModel):
     def clean(self, *args, **kwargs):
         self.check_name_conflict()
 
+        if self.soa_serial is None and not self.soa_serial_auto:
+            raise ValidationError(
+                {
+                    "soa_serial": f"soa_serial is not defined and soa_serial_auto is disabled for zone {self.name}."
+                }
+            )
+
     def save(self, *args, **kwargs):
-        self.check_name_conflict()
+        self.full_clean()
 
         new_zone = self.pk is None
         if not new_zone:

--- a/netbox_dns/models.py
+++ b/netbox_dns/models.py
@@ -335,8 +335,9 @@ class Zone(NetBoxModel):
                 .exists()
             ):
                 raise ValidationError(
-                    {"name": "A zone with name %(name)s and no view already exists."},
-                    params={"name": self.name},
+                    {
+                        "name": f"A zone with name {self.name} and no view already exists."
+                    }
                 )
 
     def clean(self, *args, **kwargs):

--- a/netbox_dns/tests/view/test_zone.py
+++ b/netbox_dns/tests/view/test_zone.py
@@ -917,7 +917,7 @@ class ZoneMoveTest(TestCase):
 
         f_zone.view = self.views[0]
 
-        with self.assertRaises(IntegrityError):
+        with self.assertRaises(ValidationError):
             f_zone.save()
 
     def test_remove_view_from_zone_zone_conflict(self):
@@ -941,7 +941,7 @@ class ZoneMoveTest(TestCase):
 
         f_zone1.view = self.views[1]
 
-        with self.assertRaises(IntegrityError):
+        with self.assertRaises(ValidationError):
             f_zone1.save()
 
     def test_delete_view_with_zones(self):

--- a/netbox_dns/tests/zone/test_auto_soa_serial.py
+++ b/netbox_dns/tests/zone/test_auto_soa_serial.py
@@ -97,12 +97,8 @@ class AutoSOASerialTest(TestCase):
         )
         f_record.save()
 
-        r_record = Record.objects.get(
-            type=RecordTypeChoices.PTR,
-            value=f"{f_record.name}.{f_zone.name}.",
-            zone=r_zone,
-        )
-        r_zone = Zone.objects.get(pk=r_record.zone.pk)
+        f_zone.refresh_from_db()
+        r_zone.refresh_from_db()
 
         self.assertTrue(int(r_zone.soa_serial) >= int(f_zone.soa_serial))
 

--- a/netbox_dns/tests/zone/test_auto_soa_serial.py
+++ b/netbox_dns/tests/zone/test_auto_soa_serial.py
@@ -1,6 +1,7 @@
 from time import time
 
 from django.test import TestCase
+from django.core.exceptions import ValidationError
 
 from netbox_dns.models import NameServer, Record, RecordTypeChoices, Zone
 
@@ -126,3 +127,11 @@ class AutoSOASerialTest(TestCase):
         r_zone = Zone.objects.get(pk=r_record.zone.pk)
 
         self.assertEqual(r_zone.soa_serial, 1)
+
+    def test_missing_soa_serial(self):
+        zone = self.zones[0]
+        zone.soa_serial = None
+        zone.soa_serial_auto = False
+
+        with self.assertRaises(ValidationError):
+            zone.save()


### PR DESCRIPTION
fixes #203 

This PR adds code that detects when a SERIAL has not been defined for a zone and SOA SERIAL autogeneration is turned off. Formerly, this was only detected when trying to add the SOA record to the zone and it didn't validate by dnspython checks, which led to a 500 error with an error message that does not make too much sense.

Now a proper error message like
```
{"soa_serial":["soa_serial is not defined and soa_serial_auto is disabled for zone zone5.example.com."]}
```
is returned with a 400 response code if a serial number cannot be determined.