### PR TITLE
Set the default type to unset when bulk editing records

### DIFF
--- a/netbox_dns/forms/record.py
+++ b/netbox_dns/forms/record.py
@@ -15,6 +15,7 @@ from netbox.forms import (
     NetBoxModelForm,
 )
 from utilities.forms import (
+    add_blank_choice,
     BulkEditNullBooleanSelect,
     DynamicModelMultipleChoiceField,
     TagFilterField,
@@ -170,7 +171,7 @@ class RecordBulkEditForm(NetBoxModelBulkEditForm):
         ),
     )
     type = forms.ChoiceField(
-        choices=RecordTypeChoices,
+        choices=add_blank_choice(RecordTypeChoices),
         required=False,
         widget=StaticSelect(),
     )


### PR DESCRIPTION
Use `add_blank_choice` for the type choices in the bulk edit form. This results in an initially empty field instead of a default value of `A`.

fixes #210