### PR TITLE
Fixed zone CSV import

### DIFF
--- a/netbox_dns/forms/zone.py
+++ b/netbox_dns/forms/zone.py
@@ -241,6 +241,7 @@ class ZoneCSVForm(NetBoxModelCSVForm):
     )
     status = CSVChoiceField(
         choices=ZoneStatusChoices,
+        required=False,
         help_text="Zone status",
     )
     default_ttl = IntegerField(
@@ -316,7 +317,14 @@ class ZoneCSVForm(NetBoxModelCSVForm):
         return self._clean_field_with_defaults("soa_ttl")
 
     def clean_soa_mname(self):
-        return self._clean_field_with_defaults("soa_mname")
+        soa_mname = self._clean_field_with_defaults("soa_mname")
+        if type(soa_mname) == str:
+            try:
+                soa_mname = NameServer.objects.get(name=soa_mname)
+            except NameServer.DoesNotExist:
+                raise ValidationError(f"Default name server {soa_mname} does not exist")
+
+        return soa_mname
 
     def clean_soa_rname(self):
         return self._clean_field_with_defaults("soa_rname")

--- a/netbox_dns/tests/zone/test_api.py
+++ b/netbox_dns/tests/zone/test_api.py
@@ -84,21 +84,18 @@ class ZoneTest(
             },
             {
                 "name": "zone9.example.com",
-                "status": "active",
                 **cls.zone_data,
                 "soa_mname": ns1.pk,
                 "view": views[0].pk,
             },
             {
                 "name": "zone9.example.com",
-                "status": "active",
                 **cls.zone_data,
                 "soa_mname": ns1.pk,
                 "view": views[1].pk,
             },
             {
                 "name": "zone9.example.com",
-                "status": "active",
                 **cls.zone_data,
                 "soa_mname": ns1.pk,
             },
@@ -106,6 +103,5 @@ class ZoneTest(
 
         cls.bulk_update_data = {
             "view": views[2].pk,
-            "status": "active",
             "tags": [t.pk for t in tags],
         }


### PR DESCRIPTION
fixes #214

This PR also fixes the behaviour of the CSV import when a `soa_mname` has not been given, in which case a default value in the config file is required. Unfortunately this didn't work, the import kept complaining that a string isn't a valid choice for `soa_mname`.