### PR TITLE
Avoid duplicate save() operation for new records

### DIFF
--- a/netbox_dns/models.py
+++ b/netbox_dns/models.py
@@ -659,7 +659,8 @@ class Record(NetBoxModel):
                 )
 
         self.ptr_record = ptr_record
-        super().save()
+        if self.pk:
+            super().save()
 
     def clean_fields(self, *args, **kwargs):
         self.type = self.type.upper()


### PR DESCRIPTION
On saving a new record, avoid calling Djano's `save()` method twice.

Though normally not a problem at all, this breaks record creation using the API for some reason. There should also be a small performance improvement, and avoiding the double save is cleaner as well.

fixes #232