### PR TITLE
Set TTL for the zones' NS records to None

### DIFF
--- a/netbox_dns/migrations/0018_update_ns_ttl.py
+++ b/netbox_dns/migrations/0018_update_ns_ttl.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+
+
+def update_ns_ttl(apps, schema_editor):
+    Zone = apps.get_model("netbox_dns", "Zone")
+
+    for zone in Zone.objects.all():
+        for nameserver in zone.nameservers.all():
+            nameserver.ttl = None
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("netbox_dns", "0017_alter_record_ttl"),
+    ]
+
+    operations = [
+        migrations.RunPython(update_ns_ttl),
+    ]

--- a/netbox_dns/migrations/0019_update_ns_ttl.py
+++ b/netbox_dns/migrations/0019_update_ns_ttl.py
@@ -12,7 +12,7 @@ def update_ns_ttl(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("netbox_dns", "0017_alter_record_ttl"),
+        ("netbox_dns", "0018_zone_arpa_network"),
     ]
 
     operations = [

--- a/netbox_dns/models.py
+++ b/netbox_dns/models.py
@@ -273,7 +273,6 @@ class Zone(NetBoxModel):
 
     def update_ns_records(self, nameservers):
         ns_name = "@"
-        ns_ttl = self.default_ttl
 
         delete_ns = self.record_set.filter(
             type=RecordTypeChoices.NS, managed=True
@@ -286,7 +285,6 @@ class Zone(NetBoxModel):
                 zone_id=self.pk,
                 type=RecordTypeChoices.NS,
                 name=ns_name,
-                ttl=ns_ttl,
                 value=ns,
                 managed=True,
             )


### PR DESCRIPTION
fixes #242 

This very small change sets a zone's default TTL to None for all new and updated zones, as well as for all existing zones via a data migration.

As a result, NS records will still follow the zone's default TTL if the zone data are created with a `$TTL` tag or similar mechanism in place (which is recommended anyway to avoid falling back to the SOA `MINIMUM_TTL` setting for successful queries).

@hatsat32: This PR can't be merged together with #240 as both have migrations. That needs to be fixed when the merge conflict pops up.