### PR TITLE
Fix FQDN generation for @ records

### DIFF
--- a/netbox_dns/models.py
+++ b/netbox_dns/models.py
@@ -626,7 +626,10 @@ class Record(NetBoxModel):
         return reverse("plugins:netbox_dns:record", kwargs={"pk": self.id})
 
     def fqdn(self):
-        return f"{self.name}.{self.zone.name}."
+        if self.name == "@":
+            return f"{self.zone.name}."
+        else:
+            return f"{self.name}.{self.zone.name}."
 
     @property
     def is_active(self):

--- a/netbox_dns/tests/record/test_auto_ptr.py
+++ b/netbox_dns/tests/record/test_auto_ptr.py
@@ -93,6 +93,27 @@ class AutoPTRTest(TestCase):
 
         self.assertEqual(r_record.value, f"{name}.{f_zone.name}.")
 
+    def test_create_apex_ipv4_ptr(self):
+        f_zone = self.zones[0]
+        r_zone = self.zones[1]
+
+        name = "@"
+        address = "10.0.1.42"
+
+        f_record = Record(
+            zone=f_zone,
+            name=name,
+            type=RecordTypeChoices.A,
+            value=address,
+            **self.record_data,
+        )
+        f_record.save()
+        r_record = Record.objects.get(
+            type=RecordTypeChoices.PTR, zone=r_zone, name=reverse_name(address, r_zone)
+        )
+
+        self.assertEqual(r_record.value, f"{f_zone.name}.")
+
     def test_remove_ipv4_ptr(self):
         f_zone = self.zones[0]
         r_zone = self.zones[1]
@@ -467,6 +488,27 @@ class AutoPTRTest(TestCase):
         )
 
         self.assertEqual(r_record.value, f"{name}.{f_zone.name}.")
+
+    def test_create_apex_ipv6_ptr(self):
+        f_zone = self.zones[0]
+        r_zone = self.zones[6]
+
+        name = "@"
+        address = "fe80:dead:beef:1::42"
+
+        f_record = Record(
+            zone=f_zone,
+            name=name,
+            type=RecordTypeChoices.AAAA,
+            value=address,
+            **self.record_data,
+        )
+        f_record.save()
+        r_record = Record.objects.get(
+            type=RecordTypeChoices.PTR, zone=r_zone, name=reverse_name(address, r_zone)
+        )
+
+        self.assertEqual(r_record.value, f"{f_zone.name}.")
 
     def test_remove_ipv6_ptr(self):
         f_zone = self.zones[0]


### PR DESCRIPTION
fixes #246

The FQDN for a record with @ as its name must be the name of the zone, not `@.` with the zone name appended.