### PR TITLE
Improved pagination for zone record/managed record tables

### DIFF
--- a/netbox_dns/templates/netbox_dns/zone_managed_record.html
+++ b/netbox_dns/templates/netbox_dns/zone_managed_record.html
@@ -38,15 +38,14 @@
         <div class="card">
           <div class="card-body">
             <div class="table-responsive">
-              {% render_table table %}
+              {% render_table table "inc/table.html" %}
             </div>
+            {# Paginator #}
+            {% include 'inc/paginator.html' with paginator=table.paginator page=table.page %}
           </div>
         </div>
 
       </form>
-
-      {# Paginator #}
-      {% include 'inc/paginator.html' with paginator=table.paginator page=table.page %}
     </div>
   </div>
 

--- a/netbox_dns/templates/netbox_dns/zone_record.html
+++ b/netbox_dns/templates/netbox_dns/zone_record.html
@@ -65,8 +65,10 @@
         <div class="card">
           <div class="card-body">
             <div class="table-responsive">
-              {% render_table table %}
+              {% render_table table "inc/table.html" %}
             </div>
+            {# Paginator #}
+            {% include 'inc/paginator.html' with paginator=table.paginator page=table.page %}
           </div>
         </div>
 
@@ -92,9 +94,6 @@
         {% endif %}
 
       </form>
-
-      {# Paginator #}
-      {% include 'inc/paginator.html' with paginator=table.paginator page=table.page %}
     </div>
   </div>
 


### PR DESCRIPTION
fixes #249 

The issue was a result of using render_table with the django-tables2 default template. Using the NetBox table.html template and moving the paginator a bit to match the standard NetBox page style should clean that up.