### PR TITLE
Modify NS and SOA records for affected zones when a NameServer object is deleted or renamed

### DIFF
--- a/netbox_dns/migrations/0022_search.py
+++ b/netbox_dns/migrations/0022_search.py
@@ -19,7 +19,6 @@ def reindex(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("extras", "0083_search"),
         ("netbox_dns", "0021_record_ip_address"),

--- a/netbox_dns/models.py
+++ b/netbox_dns/models.py
@@ -97,6 +97,18 @@ class NameServer(NetBoxModel):
         self.full_clean()
         super().save(*args, **kwargs)
 
+    def delete(self, *args, **kwargs):
+        with transaction.atomic():
+            zones = self.zones.all()
+            for zone in zones:
+                Record.objects.filter(
+                    Q(zone=zone),
+                    Q(managed=True),
+                    Q(value=f"{self.name}."),
+                    Q(type=RecordTypeChoices.NS),
+                ).delete()
+
+            super().delete(*args, **kwargs)
 
 @register_search
 class NameServerIndex(SearchIndex):

--- a/netbox_dns/models.py
+++ b/netbox_dns/models.py
@@ -110,6 +110,7 @@ class NameServer(NetBoxModel):
 
             super().delete(*args, **kwargs)
 
+
 @register_search
 class NameServerIndex(SearchIndex):
     model = NameServer

--- a/netbox_dns/models.py
+++ b/netbox_dns/models.py
@@ -95,7 +95,22 @@ class NameServer(NetBoxModel):
 
     def save(self, *args, **kwargs):
         self.full_clean()
-        super().save(*args, **kwargs)
+
+        name_changed = (
+            self.pk is not None and self.name != NameServer.objects.get(pk=self.pk).name
+        )
+
+        with transaction.atomic():
+            super().save(*args, **kwargs)
+
+            if name_changed:
+                soa_zones = self.zones_soa.all()
+                for soa_zone in soa_zones:
+                    soa_zone.update_soa_record()
+
+                zones = self.zones.all()
+                for zone in zones:
+                    zone.update_ns_records()
 
     def delete(self, *args, **kwargs):
         with transaction.atomic():
@@ -348,14 +363,14 @@ class Zone(NetBoxModel):
                 managed=True,
             )
 
-    def update_ns_records(self, nameservers):
+    def update_ns_records(self):
         ns_name = "@"
 
-        delete_ns = self.record_set.filter(
-            type=RecordTypeChoices.NS, managed=True
-        ).exclude(value__in=nameservers)
-        for record in delete_ns:
-            record.delete()
+        nameservers = [f"{nameserver.name}." for nameserver in self.nameservers.all()]
+
+        self.record_set.filter(type=RecordTypeChoices.NS, managed=True).exclude(
+            value__in=nameservers
+        ).delete()
 
         for ns in nameservers:
             Record.raw_objects.update_or_create(
@@ -517,7 +532,7 @@ class Zone(NetBoxModel):
 
     def delete(self, *args, **kwargs):
         with transaction.atomic():
-            address_records = list(self.record_set.filter(ptr_record__isnull=False))
+            address_records = self.record_set.filter(ptr_record__isnull=False)
             for record in address_records:
                 record.ptr_record.delete()
 
@@ -539,11 +554,7 @@ def update_ns_records(**kwargs):
         return
 
     zone = kwargs.get("instance")
-    nameservers = zone.nameservers.all()
-
-    new_nameservers = [f"{ns.name}." for ns in nameservers]
-
-    zone.update_ns_records(new_nameservers)
+    zone.update_ns_records()
 
 
 @register_search

--- a/netbox_dns/tests/zone/test_auto_ns.py
+++ b/netbox_dns/tests/zone/test_auto_ns.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from django.db.models import ProtectedError
 
 from netbox_dns.models import NameServer, Record, RecordTypeChoices, Zone
 
@@ -171,3 +172,60 @@ class AutoNSTest(TestCase):
         )
         ns_values = [ns.value for ns in ns_records]
         self.assertEqual([f"{nameserver2.name}."], ns_values)
+
+    def test_zone_add_ns_ns_record_added(self):
+        zone = self.zone
+        nameserver = self.nameservers[0]
+
+        zone.nameservers.add(nameserver)
+
+        ns_record = Record.objects.get(name="@", zone=zone, type=RecordTypeChoices.NS, value=f"{nameserver.name}.")
+        self.assertEqual(nameserver.name, ns_record.value.rstrip("."))
+
+    def test_zone_remove_ns_ns_record_removed(self):
+        zone = self.zone
+        nameserver = self.nameservers[1]
+
+        zone.nameservers.add(nameserver)
+
+        ns_record = Record.objects.get(name="@", zone=zone, type=RecordTypeChoices.NS, value=f"{nameserver.name}.")
+        self.assertEqual(nameserver.name, ns_record.value.rstrip("."))
+
+        zone.nameservers.remove(nameserver)
+
+        with self.assertRaises(Record.DoesNotExist):
+            Record.objects.get(name="@", zone=zone, type=RecordTypeChoices.NS, value=f"{nameserver.name}.")
+
+    def test_zone_delete_ns_ns_record_removed(self):
+        zone = self.zone
+        nameserver = self.nameservers[1]
+
+        zone.nameservers.add(nameserver)
+
+        ns_record = Record.objects.get(name="@", zone=zone, type=RecordTypeChoices.NS, value=f"{nameserver.name}.")
+        self.assertEqual(nameserver.name, ns_record.value.rstrip("."))
+
+        nameserver.delete()
+
+        with self.assertRaises(Record.DoesNotExist):
+            Record.objects.get(name="@", zone=zone, type=RecordTypeChoices.NS, value=f"{nameserver.name}.")
+
+    def test_zone_delete_soa_ns_exception(self):
+        zone = self.zone
+        nameserver = self.nameservers[0]
+
+        with self.assertRaisesRegexp(ProtectedError, r"protected foreign keys: 'Zone\.soa_mname'."):
+            nameserver.delete()
+
+
+    def test_zone_delete_soa_ns_exception_ns_record_retained(self):
+        zone = self.zone
+        nameserver = self.nameservers[0]
+
+        zone.nameservers.add(nameserver)
+
+        with self.assertRaisesRegexp(ProtectedError, r"protected foreign keys: 'Zone\.soa_mname'."):
+            nameserver.delete()
+
+        ns_record = Record.objects.get(name="@", zone=zone, type=RecordTypeChoices.NS, value=f"{nameserver.name}.")
+        self.assertEqual(nameserver.name, ns_record.value.rstrip("."))

--- a/netbox_dns/tests/zone/test_auto_ns.py
+++ b/netbox_dns/tests/zone/test_auto_ns.py
@@ -179,7 +179,9 @@ class AutoNSTest(TestCase):
 
         zone.nameservers.add(nameserver)
 
-        ns_record = Record.objects.get(name="@", zone=zone, type=RecordTypeChoices.NS, value=f"{nameserver.name}.")
+        ns_record = Record.objects.get(
+            name="@", zone=zone, type=RecordTypeChoices.NS, value=f"{nameserver.name}."
+        )
         self.assertEqual(nameserver.name, ns_record.value.rstrip("."))
 
     def test_zone_remove_ns_ns_record_removed(self):
@@ -188,13 +190,20 @@ class AutoNSTest(TestCase):
 
         zone.nameservers.add(nameserver)
 
-        ns_record = Record.objects.get(name="@", zone=zone, type=RecordTypeChoices.NS, value=f"{nameserver.name}.")
+        ns_record = Record.objects.get(
+            name="@", zone=zone, type=RecordTypeChoices.NS, value=f"{nameserver.name}."
+        )
         self.assertEqual(nameserver.name, ns_record.value.rstrip("."))
 
         zone.nameservers.remove(nameserver)
 
         with self.assertRaises(Record.DoesNotExist):
-            Record.objects.get(name="@", zone=zone, type=RecordTypeChoices.NS, value=f"{nameserver.name}.")
+            Record.objects.get(
+                name="@",
+                zone=zone,
+                type=RecordTypeChoices.NS,
+                value=f"{nameserver.name}.",
+            )
 
     def test_zone_delete_ns_ns_record_removed(self):
         zone = self.zone
@@ -202,21 +211,29 @@ class AutoNSTest(TestCase):
 
         zone.nameservers.add(nameserver)
 
-        ns_record = Record.objects.get(name="@", zone=zone, type=RecordTypeChoices.NS, value=f"{nameserver.name}.")
+        ns_record = Record.objects.get(
+            name="@", zone=zone, type=RecordTypeChoices.NS, value=f"{nameserver.name}."
+        )
         self.assertEqual(nameserver.name, ns_record.value.rstrip("."))
 
         nameserver.delete()
 
         with self.assertRaises(Record.DoesNotExist):
-            Record.objects.get(name="@", zone=zone, type=RecordTypeChoices.NS, value=f"{nameserver.name}.")
+            Record.objects.get(
+                name="@",
+                zone=zone,
+                type=RecordTypeChoices.NS,
+                value=f"{nameserver.name}.",
+            )
 
     def test_zone_delete_soa_ns_exception(self):
         zone = self.zone
         nameserver = self.nameservers[0]
 
-        with self.assertRaisesRegexp(ProtectedError, r"protected foreign keys: 'Zone\.soa_mname'."):
+        with self.assertRaisesRegexp(
+            ProtectedError, r"protected foreign keys: 'Zone\.soa_mname'."
+        ):
             nameserver.delete()
-
 
     def test_zone_delete_soa_ns_exception_ns_record_retained(self):
         zone = self.zone
@@ -224,8 +241,12 @@ class AutoNSTest(TestCase):
 
         zone.nameservers.add(nameserver)
 
-        with self.assertRaisesRegexp(ProtectedError, r"protected foreign keys: 'Zone\.soa_mname'."):
+        with self.assertRaisesRegexp(
+            ProtectedError, r"protected foreign keys: 'Zone\.soa_mname'."
+        ):
             nameserver.delete()
 
-        ns_record = Record.objects.get(name="@", zone=zone, type=RecordTypeChoices.NS, value=f"{nameserver.name}.")
+        ns_record = Record.objects.get(
+            name="@", zone=zone, type=RecordTypeChoices.NS, value=f"{nameserver.name}."
+        )
         self.assertEqual(nameserver.name, ns_record.value.rstrip("."))


### PR DESCRIPTION
fixes #279

This fixes the above issue by updating NS and SOA records for affected zones when a NameServer object is deleted or renamed.

Additionally, some new tests covering both cases were added, and the `update_ns_records()` got some performance improvement as well.