### PR TITLE
Compatibility update for NetBox 3.5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.8"
       - name: Install latest version of Poetry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.8"
       - name: Install latest version of Poetry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           path: netbox-dns
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">NetBox DNS</h1>
 
-<p align="center"><i>NetBox DNS is a NetBox plugin for managing DNS data.</i></p>
+<p align="center"><i>NetBox DNS is a NetBox plugin for managing DNS views, zones, name servers and records.</i></p>
 
 <div align="center">
 <a href="https://pypi.org/project/netbox-dns/"><img src="https://img.shields.io/pypi/v/netbox-dns" alt="PyPi"/></a>
@@ -14,16 +14,17 @@
 
 ## Features
 
-* Manage name servers
+* Manage DNS name servers
 * Manage DNS zone information, automatically generating SOA and NS records
+* Manage DNS records
 * Automatically create and update PTR records for A and AAAA records
-* Optionally organize zones in views to cater for split horizon DNS and multi site deployments
+* Optionally organize DNS zones in views to cater for split horizon DNS and multi-site deployments
 
 NetBox DNS is using the standardized NetBox plugin interface, so it also takes advantage of the NetBox tagging and change log features.
 
 ## Requirements
 
-* NetBox 3.4 or higher
+* NetBox 3.5 or higher
 * Python 3.8 or higher
 
 ## Installation & Configuration

--- a/netbox_dns/__init__.py
+++ b/netbox_dns/__init__.py
@@ -7,7 +7,7 @@ class DNSConfig(PluginConfig):
     name = "netbox_dns"
     verbose_name = "Netbox DNS"
     description = "Netbox DNS"
-    min_version = "3.4.0"
+    min_version = "3.5-beta2"
     version = __version__
     author = "Aurora Research Lab"
     author_email = "info@aurorabilisim.com"

--- a/netbox_dns/__init__.py
+++ b/netbox_dns/__init__.py
@@ -7,7 +7,7 @@ class DNSConfig(PluginConfig):
     name = "netbox_dns"
     verbose_name = "Netbox DNS"
     description = "Netbox DNS"
-    min_version = "3.5-beta2"
+    min_version = "3.5"
     version = __version__
     author = "Aurora Research Lab"
     author_email = "info@aurorabilisim.com"

--- a/netbox_dns/forms/nameserver.py
+++ b/netbox_dns/forms/nameserver.py
@@ -7,7 +7,7 @@ from netbox.forms import (
     NetBoxModelForm,
 )
 
-from utilities.forms import TagFilterField
+from utilities.forms.fields import TagFilterField
 
 from netbox_dns.models import NameServer
 from netbox_dns.utilities import name_to_unicode

--- a/netbox_dns/forms/nameserver.py
+++ b/netbox_dns/forms/nameserver.py
@@ -1,4 +1,4 @@
-from django.forms import CharField
+from django import forms
 
 from netbox.forms import (
     NetBoxModelBulkEditForm,
@@ -33,7 +33,7 @@ class NameServerFilterForm(NetBoxModelFilterSetForm):
 
     model = NameServer
 
-    name = CharField(
+    name = forms.CharField(
         required=False,
         label="Name",
     )
@@ -50,7 +50,7 @@ class NameServerImportForm(NetBoxModelImportForm):
 class NameServerBulkEditForm(NetBoxModelBulkEditForm):
     model = NameServer
 
-    description = CharField(max_length=200, required=False)
+    description = forms.CharField(max_length=200, required=False)
 
     class Meta:
         nullable_fields = ("description",)

--- a/netbox_dns/forms/record.py
+++ b/netbox_dns/forms/record.py
@@ -7,17 +7,15 @@ from netbox.forms import (
     NetBoxModelImportForm,
     NetBoxModelForm,
 )
-from utilities.forms import (
-    add_blank_choice,
-    BulkEditNullBooleanSelect,
+from utilities.forms.fields import (
     DynamicModelMultipleChoiceField,
     TagFilterField,
     CSVChoiceField,
     CSVModelChoiceField,
     DynamicModelChoiceField,
-    APISelect,
-    add_blank_choice,
 )
+from utilities.forms.widgets import BulkEditNullBooleanSelect, APISelect
+from utilities.forms import add_blank_choice
 
 from netbox_dns.models import View, Zone, Record, RecordTypeChoices, RecordStatusChoices
 from netbox_dns.utilities import name_to_unicode

--- a/netbox_dns/forms/record.py
+++ b/netbox_dns/forms/record.py
@@ -1,11 +1,4 @@
 from django import forms
-
-from django.forms import (
-    CharField,
-    IntegerField,
-    BooleanField,
-    NullBooleanField,
-)
 from django.urls import reverse_lazy
 
 from netbox.forms import (
@@ -40,11 +33,11 @@ class RecordForm(NetBoxModelForm):
         if initial_name:
             self.initial["name"] = name_to_unicode(initial_name)
 
-    disable_ptr = BooleanField(
+    disable_ptr = forms.BooleanField(
         label="Disable PTR",
         required=False,
     )
-    ttl = IntegerField(
+    ttl = forms.IntegerField(
         required=False,
         label="TTL",
     )
@@ -74,11 +67,11 @@ class RecordFilterForm(NetBoxModelFilterSetForm):
         choices=add_blank_choice(RecordTypeChoices),
         required=False,
     )
-    name = CharField(
+    name = forms.CharField(
         required=False,
         label="Name",
     )
-    value = CharField(
+    value = forms.CharField(
         required=False,
         label="Value",
     )
@@ -137,7 +130,7 @@ class RecordImportForm(NetBoxModelImportForm):
         required=False,
         help_text="Record status",
     )
-    ttl = IntegerField(
+    ttl = forms.IntegerField(
         required=False,
         help_text="TTL",
     )
@@ -184,7 +177,7 @@ class RecordBulkEditForm(NetBoxModelBulkEditForm):
         choices=add_blank_choice(RecordTypeChoices),
         required=False,
     )
-    value = CharField(
+    value = forms.CharField(
         required=False,
         label="Value",
     )
@@ -192,14 +185,14 @@ class RecordBulkEditForm(NetBoxModelBulkEditForm):
         choices=add_blank_choice(RecordStatusChoices),
         required=False,
     )
-    ttl = IntegerField(
+    ttl = forms.IntegerField(
         required=False,
         label="TTL",
     )
-    disable_ptr = NullBooleanField(
+    disable_ptr = forms.NullBooleanField(
         required=False, widget=BulkEditNullBooleanSelect(), label="Disable PTR"
     )
-    description = CharField(max_length=200, required=False)
+    description = forms.CharField(max_length=200, required=False)
 
     fieldsets = (
         (

--- a/netbox_dns/forms/record.py
+++ b/netbox_dns/forms/record.py
@@ -19,12 +19,10 @@ from utilities.forms import (
     BulkEditNullBooleanSelect,
     DynamicModelMultipleChoiceField,
     TagFilterField,
-    StaticSelect,
     CSVChoiceField,
     CSVModelChoiceField,
     DynamicModelChoiceField,
     APISelect,
-    StaticSelectMultiple,
     add_blank_choice,
 )
 
@@ -66,12 +64,6 @@ class RecordForm(NetBoxModelForm):
             "tags",
         )
 
-        widgets = {
-            "zone": StaticSelect(),
-            "type": StaticSelect(),
-            "status": StaticSelect(),
-        }
-
 
 class RecordFilterForm(NetBoxModelFilterSetForm):
     """Form for filtering Record instances."""
@@ -81,7 +73,6 @@ class RecordFilterForm(NetBoxModelFilterSetForm):
     type = forms.MultipleChoiceField(
         choices=add_blank_choice(RecordTypeChoices),
         required=False,
-        widget=StaticSelectMultiple(),
     )
     name = CharField(
         required=False,
@@ -94,7 +85,6 @@ class RecordFilterForm(NetBoxModelFilterSetForm):
     status = forms.ChoiceField(
         choices=add_blank_choice(RecordStatusChoices),
         required=False,
-        widget=StaticSelect(),
     )
     zone_id = DynamicModelMultipleChoiceField(
         queryset=Zone.objects.all(),
@@ -193,7 +183,6 @@ class RecordBulkEditForm(NetBoxModelBulkEditForm):
     type = forms.ChoiceField(
         choices=add_blank_choice(RecordTypeChoices),
         required=False,
-        widget=StaticSelect(),
     )
     value = CharField(
         required=False,
@@ -202,7 +191,6 @@ class RecordBulkEditForm(NetBoxModelBulkEditForm):
     status = forms.ChoiceField(
         choices=add_blank_choice(RecordStatusChoices),
         required=False,
-        widget=StaticSelect(),
     )
     ttl = IntegerField(
         required=False,

--- a/netbox_dns/forms/view.py
+++ b/netbox_dns/forms/view.py
@@ -6,7 +6,7 @@ from netbox.forms import (
     NetBoxModelImportForm,
     NetBoxModelForm,
 )
-from utilities.forms import TagFilterField
+from utilities.forms.fields import TagFilterField
 
 from netbox_dns.models import View
 

--- a/netbox_dns/forms/view.py
+++ b/netbox_dns/forms/view.py
@@ -1,4 +1,4 @@
-from django.forms import CharField
+from django import forms
 
 from netbox.forms import (
     NetBoxModelBulkEditForm,
@@ -22,7 +22,7 @@ class ViewForm(NetBoxModelForm):
 class ViewFilterForm(NetBoxModelFilterSetForm):
     """Form for filtering View instances."""
 
-    name = CharField(
+    name = forms.CharField(
         required=False,
         label="Name",
     )
@@ -40,7 +40,7 @@ class ViewImportForm(NetBoxModelImportForm):
 class ViewBulkEditForm(NetBoxModelBulkEditForm):
     model = View
 
-    description = CharField(max_length=200, required=False)
+    description = forms.CharField(max_length=200, required=False)
 
     class Meta:
         nullable_fields = ["description"]

--- a/netbox_dns/forms/zone.py
+++ b/netbox_dns/forms/zone.py
@@ -10,16 +10,15 @@ from netbox.forms import (
     NetBoxModelImportForm,
     NetBoxModelForm,
 )
-from utilities.forms import (
-    BulkEditNullBooleanSelect,
+from utilities.forms.fields import (
     DynamicModelMultipleChoiceField,
     TagFilterField,
     CSVChoiceField,
     CSVModelChoiceField,
     DynamicModelChoiceField,
-    APISelect,
-    add_blank_choice,
 )
+from utilities.forms.widgets import BulkEditNullBooleanSelect, APISelect
+from utilities.forms import add_blank_choice
 
 from netbox_dns.models import View, Zone, ZoneStatusChoices, NameServer
 from netbox_dns.utilities import name_to_unicode

--- a/netbox_dns/forms/zone.py
+++ b/netbox_dns/forms/zone.py
@@ -20,7 +20,6 @@ from utilities.forms import (
     BulkEditNullBooleanSelect,
     DynamicModelMultipleChoiceField,
     TagFilterField,
-    StaticSelect,
     CSVChoiceField,
     CSVModelChoiceField,
     DynamicModelChoiceField,
@@ -197,11 +196,6 @@ class ZoneForm(NetBoxModelForm):
             "soa_expire",
             "soa_minimum",
         )
-        widgets = {
-            "view": StaticSelect(),
-            "status": StaticSelect(),
-            "soa_mname": StaticSelect(),
-        }
         help_texts = {
             "view": "View the zone belongs to",
             "soa_mname": "Primary name server for the zone",
@@ -221,7 +215,6 @@ class ZoneFilterForm(NetBoxModelFilterSetForm):
     status = forms.ChoiceField(
         choices=add_blank_choice(ZoneStatusChoices),
         required=False,
-        widget=StaticSelect(),
     )
     name = CharField(
         required=False,
@@ -399,7 +392,6 @@ class ZoneBulkEditForm(NetBoxModelBulkEditForm):
     status = forms.ChoiceField(
         choices=add_blank_choice(ZoneStatusChoices),
         required=False,
-        widget=StaticSelect(),
     )
     nameservers = DynamicModelMultipleChoiceField(
         queryset=NameServer.objects.all(),

--- a/netbox_dns/forms/zone.py
+++ b/netbox_dns/forms/zone.py
@@ -2,12 +2,6 @@ from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator, MaxValueValidator
-from django.forms import (
-    CharField,
-    IntegerField,
-    BooleanField,
-    NullBooleanField,
-)
 from django.urls import reverse_lazy
 
 from netbox.forms import (
@@ -38,53 +32,53 @@ class ZoneForm(NetBoxModelForm):
         queryset=NameServer.objects.all(),
         required=False,
     )
-    default_ttl = IntegerField(
+    default_ttl = forms.IntegerField(
         required=False,
         label="Default TTL",
         help_text="Default TTL for new records in this zone",
         validators=[MinValueValidator(1)],
     )
-    soa_ttl = IntegerField(
+    soa_ttl = forms.IntegerField(
         required=True,
         label="SOA TTL",
         help_text="TTL for the SOA record of the zone",
         validators=[MinValueValidator(1)],
     )
-    soa_rname = CharField(
+    soa_rname = forms.CharField(
         required=True,
         label="SOA Responsible",
         help_text="Mailbox of the zone's administrator",
     )
-    soa_serial_auto = BooleanField(
+    soa_serial_auto = forms.BooleanField(
         required=False,
         label="Generate SOA Serial",
         help_text="Automatically generate the SOA Serial",
     )
-    soa_serial = IntegerField(
+    soa_serial = forms.IntegerField(
         required=False,
         label="SOA Serial",
         help_text="Serial number of the current zone data version",
         validators=[MinValueValidator(1)],
     )
-    soa_refresh = IntegerField(
+    soa_refresh = forms.IntegerField(
         required=True,
         label="SOA Refresh",
         help_text="Refresh interval for secondary name servers",
         validators=[MinValueValidator(1)],
     )
-    soa_retry = IntegerField(
+    soa_retry = forms.IntegerField(
         required=True,
         label="SOA Retry",
         help_text="Retry interval for secondary name servers",
         validators=[MinValueValidator(1)],
     )
-    soa_expire = IntegerField(
+    soa_expire = forms.IntegerField(
         required=True,
         label="SOA Expire",
         help_text="Expire time after which the zone is considered unavailable",
         validators=[MinValueValidator(1)],
     )
-    soa_minimum = IntegerField(
+    soa_minimum = forms.IntegerField(
         required=True,
         label="SOA Minimum TTL",
         help_text="Minimum TTL for negative results, e.g. NXRRSET",
@@ -216,7 +210,7 @@ class ZoneFilterForm(NetBoxModelFilterSetForm):
         choices=add_blank_choice(ZoneStatusChoices),
         required=False,
     )
-    name = CharField(
+    name = forms.CharField(
         required=False,
         label="Name",
     )
@@ -242,11 +236,11 @@ class ZoneImportForm(NetBoxModelImportForm):
         required=False,
         help_text="Zone status",
     )
-    default_ttl = IntegerField(
+    default_ttl = forms.IntegerField(
         required=False,
         help_text="Default TTL",
     )
-    soa_ttl = IntegerField(
+    soa_ttl = forms.IntegerField(
         required=False,
         help_text="TTL for the SOA record of the zone",
     )
@@ -259,31 +253,31 @@ class ZoneImportForm(NetBoxModelImportForm):
             "invalid_choice": "Nameserver not found.",
         },
     )
-    soa_rname = CharField(
+    soa_rname = forms.CharField(
         required=False,
         help_text="Mailbox of the zone's administrator",
     )
-    soa_serial_auto = BooleanField(
+    soa_serial_auto = forms.BooleanField(
         required=False,
         help_text="Generate the SOA serial",
     )
-    soa_serial = IntegerField(
+    soa_serial = forms.IntegerField(
         required=False,
         help_text="Serial number of the current zone data version",
     )
-    soa_refresh = IntegerField(
+    soa_refresh = forms.IntegerField(
         required=False,
         help_text="Refresh interval for secondary name servers",
     )
-    soa_retry = IntegerField(
+    soa_retry = forms.IntegerField(
         required=False,
         help_text="Retry interval for secondary name servers",
     )
-    soa_expire = IntegerField(
+    soa_expire = forms.IntegerField(
         required=False,
         help_text="Expire time after which the zone is considered unavailable",
     )
-    soa_minimum = IntegerField(
+    soa_minimum = forms.IntegerField(
         required=False,
         help_text="Minimum TTL for negative results, e.g. NXRRSET",
     )
@@ -397,13 +391,13 @@ class ZoneBulkEditForm(NetBoxModelBulkEditForm):
         queryset=NameServer.objects.all(),
         required=False,
     )
-    default_ttl = IntegerField(
+    default_ttl = forms.IntegerField(
         required=False,
         label="Default TTL",
         validators=[MinValueValidator(1)],
     )
-    description = CharField(max_length=200, required=False)
-    soa_ttl = IntegerField(
+    description = forms.CharField(max_length=200, required=False)
+    soa_ttl = forms.IntegerField(
         required=False,
         label="SOA TTL",
         validators=[MinValueValidator(1)],
@@ -418,36 +412,36 @@ class ZoneBulkEditForm(NetBoxModelBulkEditForm):
             }
         ),
     )
-    soa_rname = CharField(
+    soa_rname = forms.CharField(
         required=False,
         label="SOA Responsible",
     )
-    soa_serial_auto = NullBooleanField(
+    soa_serial_auto = forms.NullBooleanField(
         required=False,
         widget=BulkEditNullBooleanSelect(),
         label="Generate SOA Serial",
     )
-    soa_serial = IntegerField(
+    soa_serial = forms.IntegerField(
         required=False,
         label="SOA Serial",
         validators=[MinValueValidator(1), MaxValueValidator(4294967295)],
     )
-    soa_refresh = IntegerField(
+    soa_refresh = forms.IntegerField(
         required=False,
         label="SOA Refresh",
         validators=[MinValueValidator(1)],
     )
-    soa_retry = IntegerField(
+    soa_retry = forms.IntegerField(
         required=False,
         label="SOA Retry",
         validators=[MinValueValidator(1)],
     )
-    soa_expire = IntegerField(
+    soa_expire = forms.IntegerField(
         required=False,
         label="SOA Expire",
         validators=[MinValueValidator(1)],
     )
-    soa_minimum = IntegerField(
+    soa_minimum = forms.IntegerField(
         required=False,
         label="SOA Minimum TTL",
         validators=[MinValueValidator(1)],

--- a/netbox_dns/tests/zone/test_views.py
+++ b/netbox_dns/tests/zone/test_views.py
@@ -73,7 +73,7 @@ class ZoneTestCase(
         )
 
         cls.csv_update_data = (
-            "id,name,status,description,view",
+            "id,status,description,view",
             f"{cls.zones[0].pk},{ZoneStatusChoices.STATUS_PARKED},test-zone1,",
             f"{cls.zones[1].pk},{ZoneStatusChoices.STATUS_ACTIVE},test-zone2,{cls.views[0].name}",
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "netbox-dns"
 version = "0.17.0"
-description = "Netbox Dns is a netbox plugin for managing zone, nameserver and record inventory."
+description = "NetBox DNS is a NetBox plugin for managing DNS views, zones, name servers and records."
 readme = "README.md"
 homepage = "https://github.com/auroraresearchlab/netbox-dns"
 repository = "https://github.com/auroraresearchlab/netbox-dns"


### PR DESCRIPTION
This PR provides compatibility with NetBox 3.5.

Please note that starting from this release, NetBox DNS will no longer be compatible with NetBox 3.4 and lower. On the other hand, it requires NetBox 3.5 or higher.

If you are staying with NetBox 3.4.x please use NetBox DNS 0.17.0.

Fixes #293